### PR TITLE
fix building on launchpad

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+hyne (1.8.2-git) precise; urgency=low
+
+  * Bump debian revison to fix building of dailys after switch to github
+  
+ -- Chris Rizzitello <sithlord48@gmail.com>  Fri, 06 Feb 2015 21:20:23 -0400
+
 hyne (1.8.2) precise; urgency=low
 
   * [FF8 rerelease] Metadata.xml (Cloud saves) can be updated manually (File > Sign saves for the Cloud...).


### PR DESCRIPTION
bump up the debian revision so launchpad will replace the older sourceforge version of the package