### PR TITLE
Customize plist with few new entries, like version

### DIFF
--- a/Data.cpp
+++ b/Data.cpp
@@ -26,6 +26,7 @@ Abilities Data::_abilities;
 Magics Data::_magic;
 Items Data::_items;
 Locations Data::_locations;
+Cities Data::_cities;
 Weapons Data::_weapons;
 Names Data::_names;
 GfNames Data::_gfnames;
@@ -134,6 +135,18 @@ void Locations::fillList()
 		  << QObject::tr("Cockpit - Hydre","208") << QObject::tr("Siège passager - Hydre","209") << QObject::tr("Couloir - Hydre","210") << QObject::tr("Hangar - Hydre","211") << QObject::tr("Accès - Hydre","212") << QObject::tr("Air Room - Hydre","213") << QObject::tr("Salle de pression - Hydre","214") << QObject::tr("Centre de recherches Deep Sea","215") << QObject::tr("Laboratoire - Deep Sea","216") << QObject::tr("Salle de travail - Deep Sea","217") << QObject::tr("Fouilles - Deep Sea","218") << QObject::tr("Salle de contrôle - Base lunaire","219") << QObject::tr("Centre médical - Base lunaire","220") << QObject::tr("Pod - Base lunaire","221") << QObject::tr("Dock - Base lunaire","222") << QObject::tr("Passage - Base lunaire","223")
 		  << QObject::tr("Vestiaire - Base lunaire","224") << QObject::tr("Habitats - Base lunaire","225") << QObject::tr("Hyper Espace","226") << QObject::tr("Forêt Chocobo","227") << QObject::tr("Jungle","228") << QObject::tr("Citadelle d'Ultimecia - Vestibule","229") << QObject::tr("Citadelle d'Ultimecia - Hall","230") << QObject::tr("Citadelle d'Ultimecia - Terrasse","231") << QObject::tr("Citadelle d'Ultimecia - Cave","232") << QObject::tr("Citadelle d'Ultimecia - Couloir","233") << QObject::tr("Elévateur - Citadelle","234") << QObject::tr("Escalier - Citadelle d'Ultimecia","235") << QObject::tr("Salle du trésor - Citadelle","236") << QObject::tr("Salle de rangement - Citadelle","237") << QObject::tr("Citadelle d'Ultimecia - Galerie","238") << QObject::tr("Citadelle d'Ultimecia - Ecluse","239")
 		  << QObject::tr("Citadelle - Armurerie","240") << QObject::tr("Citadelle d'Ultimecia - Prison","241") << QObject::tr("Citadelle d'Ultimecia - Fossé","242") << QObject::tr("Citadelle d'Ultimecia - Jardin","243") << QObject::tr("Citadelle d'Ultimecia - Chapelle","244") << QObject::tr("Clocher - Citadelle d'Ultimecia","245") << QObject::tr("Chambre d'Ultimecia - Citadelle","246") << QString("???") << QObject::tr("Citadelle d'Ultimecia","248") << QObject::tr("Salle d'initiation","249") << QObject::tr("Reine des cartes","250") << QString("???") << QString("???") << QString("???") << QString("???") << QString("???");
+}
+
+void Cities::fillList()
+{
+	_list << QObject::tr("Balamb City") << QObject::tr("Deling City") << QObject::tr("Shumi Village")
+	      << QObject::tr("Winhill") << QObject::tr("Dollet") << QObject::tr("Horizon")
+	      << QObject::tr("Lunar Gate") << QObject::tr("Esthar City") << QObject::tr("Timber")
+	      << QObject::tr("BGU") << QObject::tr("GGU") << QObject::tr("TGU") << QObject::tr("Ruines de Centra")
+	      << QObject::tr("Orphelinat") << QObject::tr("Salt Lake") << QObject::tr("Forêt des novices")
+	      << QObject::tr("Forêt Classica") << QObject::tr("Forêt de l'errance") << QObject::tr("Sanctuaire des chocobos")
+	      << QObject::tr("Forêt clôturée") << QObject::tr("Forêt fun") << QObject::tr("Forêt de la solitude")
+	      << QObject::tr("Pod de secours");
 }
 
 void Weapons::fillList()
@@ -257,6 +270,7 @@ void Data::reload()
 	_magic.clear();
 	_items.clear();
 	_locations.clear();
+	_cities.clear();
 	_weapons.clear();
 	_names.clear();
 	_gfnames.clear();
@@ -906,6 +920,31 @@ const int Data::drawPointsLoc[256] =
 	51, 51, 51, 51, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19,
 	19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19,
 	19, 19, 19, 19, 19, 1, 1, 15, 20, 43, 43, 43, 43, 47, 48, -1
+};
+
+const Point Data::wmLocation[21] =
+{
+	P(0, 0, 0, 0, Cities::Balamb),
+	P(3680, 99, 412, 7, Cities::Dollet),
+	P(21744, 113, 1176, 6, Cities::Timber),
+	P(22576, 97, 898, 6, Cities::GGU),
+	P(15488, 80, 2256, 8, Cities::Deling),
+	P(4259, 258, 152, 64, Cities::Winhill),
+	P(-897, -847, 49, 192, Cities::CentraRuins),
+	P(-139, -882, 12, 0, Cities::Orphanage),
+	P(-1244, -2127, 481, 232, Cities::TGU),
+	P(-35, -5853, 5, 0, Cities::ShumiVillage),
+	P(724, -869, 163, 128, Cities::SaltLake),
+	P(12, 384, 22, 97, Cities::Esthar),
+	P(10215, -8591, 64, 0, Cities::LunarGate),
+	P(-241, -3315, 150, 0, Cities::ChocoboBeginner),
+	P(147, -2467, 47, 0, Cities::ChocoboBasics),
+	P(390, -3239, 81, 16, Cities::ChocoboRoaming),
+	P(-63, -1764, 67, 0, Cities::ChocoboSanctuary),
+	P(-181, -1594, 20, 0, Cities::ChocoboEnclosed),
+	P(-708, -593, 52, 224, Cities::ChocoboFun),
+	P(-200, -2292, 138, 0, Cities::ChocoboSolitude),
+	P(210, -8585, 19, 0, Cities::RescuePod)
 };
 
 QStringList Data::maplist()

--- a/Data.h
+++ b/Data.h
@@ -104,6 +104,40 @@ protected:
 	virtual void fillList();
 };
 
+class Cities : public DataList
+{
+public:
+	enum City {
+		Balamb,
+		Deling,
+		ShumiVillage,
+		Winhill,
+		Dollet,
+		Horizon,
+		LunarGate,
+		Esthar,
+		Timber,
+		BGU,
+		GGU,
+		TGU,
+		CentraRuins,
+		Orphanage,
+		SaltLake,
+		ChocoboBeginner,
+		ChocoboBasics,
+		ChocoboRoaming,
+		ChocoboSanctuary,
+		ChocoboEnclosed,
+		ChocoboFun,
+		ChocoboSolitude,
+		RescuePod
+	};
+
+	Cities() {}
+protected:
+	virtual void fillList();
+};
+
 class Weapons : public DataList
 {
 public:
@@ -181,6 +215,21 @@ private:
 	Names *_names;
 };
 
+struct Point {
+	inline Point(qint16 x, qint16 y, qint16 z, qint16 dir, Cities::City city) {
+		this->x = x;
+		this->y = y;
+		this->z = z;
+		this->dir = dir;
+		this->city = quint8(city);
+	}
+	qint16 x, y, z, dir;
+	quint8 city;
+};
+
+#define P(x, y, z, dir, city) \
+	Point(x, y, z, dir, city)
+
 class Data
 {
 public:
@@ -190,6 +239,7 @@ public:
 	static const cInt momentLocation[403];
 	static const int drawPoints[256];
 	static const int drawPointsLoc[256];
+	static const Point wmLocation[21];
 
 	static void reload();
 
@@ -197,6 +247,7 @@ public:
 	static inline Magics &magics() { return _magic; }
 	static inline Items &items() { return _items; }
 	static inline Locations &locations() { return _locations; }
+	static inline Cities &cities() { return _cities; }
 	static inline Weapons &weapons() { return _weapons; }
 	static inline Names &names() { return _names; }
 	static inline GfNames &gfnames() { return _gfnames; }
@@ -216,6 +267,7 @@ private:
 	static Magics _magic;
 	static Items _items;
 	static Locations _locations;
+	static Cities _cities;
 	static Weapons _weapons;
 	static Names _names;
 	static GfNames _gfnames;

--- a/FF8Installation.cpp
+++ b/FF8Installation.cpp
@@ -31,10 +31,23 @@ FF8Installation::FF8Installation() :
 FF8Installation::FF8Installation(Type type) :
 	_type(type)
 {
+	QStringList appDataLocations;
+	QString path;
+
 	switch(type) {
 	case Standard:
 		_appPath = standardFF8AppPath();
-		_savePaths.append(_appPath + "/save"); // TODO: \AppData\Local\VirtualStore\Program Files\Eidos Interactive\Square Soft, Inc\FINAL FANTASY VIII
+		appDataLocations = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
+		if (!appDataLocations.isEmpty()) {
+			path = appDataLocations.first().append("/VirtualStore/").append(QString(_appPath).replace(QRegExp("^\\w+:/"), ""));
+			if (!QFile::exists(path)) {
+				path = QString();
+			}
+		}
+		if (path.isEmpty()) {
+			path = _appPath;
+		}
+		_savePaths.append(path + "/save");
 		break;
 	case Steam:
 		_appPath = steamFF8AppPath();

--- a/Hyne.desktop
+++ b/Hyne.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Version=1.9.3
+Version=1.10.0
 Name=Hyne
 GenericName=FF8 Save Game Editor
 GenericName[fr]=Éditeur de sauvegarde FF8

--- a/Hyne.plist
+++ b/Hyne.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleExecutable</key>
+        <string>${EXECUTABLE_NAME}</string>
+        <key>CFBundleIconFile</key>
+        <string>${ASSETCATALOG_COMPILER_APPICON_NAME}</string>
+        <key>CFBundleIdentifier</key>
+        <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+        <key>CFBundleShortVersionString</key>
+        <string>${QMAKE_FULL_VERSION}</string>
+        <key>CFBundleVersion</key>
+        <string>${QMAKE_FULL_VERSION}</string>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>${EXECUTABLE_NAME}</string>
+        <key>CFBundlePackageType</key>
+        <string>APPL</string>
+        <key>LSMinimumSystemVersion</key>
+        <string>${MACOSX_DEPLOYMENT_TARGET}</string>
+        <key>NSPrincipalClass</key>
+        <string>NSApplication</string>
+        <key>NSSupportsAutomaticGraphicsSwitching</key>
+        <true/>
+</dict>
+</plist>

--- a/Hyne.pro
+++ b/Hyne.pro
@@ -144,6 +144,8 @@ CODECFORSRC = UTF-8
 # Icons
 macx {
     ICON = images/hyne.icns
+    QMAKE_INFO_PLIST = Hyne.plist
+    QMAKE_TARGET_BUNDLE_PREFIX = com.myst6re
 }
 win32 {
     RC_ICONS = "images/hyne.ico"
@@ -178,4 +180,5 @@ unix:!macx:!symbian {
 DISTFILES += Hyne.desktop \
     README.md \
     .travis.yml \
-    appveyor.yml
+    appveyor.yml \
+    Hyne.plist

--- a/Hyne.pro
+++ b/Hyne.pro
@@ -4,7 +4,7 @@ if(win32|macx) {
 } else {
     TARGET = hyne
 }
-VERSION = 1.9.3
+VERSION = 1.10.0b
 
 DEFINES += PROGVERSION=$$VERSION PROGNAME=Hyne
 

--- a/PageWidgets/GfEditor.cpp
+++ b/PageWidgets/GfEditor.cpp
@@ -212,7 +212,7 @@ QWidget *GfEditor::buildPage2()
 void GfEditor::fillPage()
 {
 	savePage();
-	this->id = gfListe->currentRow();
+	this->id = quint8(gfListe->currentRow());
 
 	for(quint8 i=0 ; i<16 ; ++i)
 	{
@@ -404,7 +404,7 @@ void GfEditor::remove_C()
 		liste2->scrollToItem(item);
 		liste2->setCurrentItem(item);
 	}
-	GF_SET_FORGOTTEN(*gf_data, forgotten & 0xFFFF);
+	GF_SET_FORGOTTEN(*gf_data, forgotten & 0xFFFFFF);
 	setCompleteAbility(abilityID, false);
 }
 

--- a/PageWidgets/PartyEditor.cpp
+++ b/PageWidgets/PartyEditor.cpp
@@ -61,7 +61,18 @@ void PartyEditor::buildWidget()
 
 	QGroupBox *positionGBE = new QGroupBox(tr("Position"), this);
 
+	presetPosE = new QComboBox(positionGBE);
+	presetPosE->addItem(tr("Position prédéfinie"));
+	for(i=0 ; i<21 ; ++i) {
+		Point p = Data::wmLocation[i];
+		presetPosE->addItem(Data::cities().at(p.city), quint32(p.x) | quint32(p.y) << 16);
+		presetPosE->setItemData(i + 1, quint32(p.z) | quint32(p.dir) << 16, Qt::UserRole + 1);
+	}
+
+	connect(presetPosE, SIGNAL(currentIndexChanged(int)), SLOT(setPosPresetFromIndex(int)));
+
 	QGridLayout *positionGBL = new QGridLayout(positionGBE);
+	positionGBL->addWidget(presetPosE, 0, 0);
 	positionGBL->addWidget(new QLabel(tr("X :")), 0, 1);
 	positionGBL->addWidget(new QLabel(tr("Y :")), 0, 2);
 	positionGBL->addWidget(new QLabel(tr("Triangle ID :")), 0, 3);
@@ -91,6 +102,8 @@ void PartyEditor::buildWidget()
 	moduleE->addItem(tr("Terrain"), 1);
 	moduleE->addItem(tr("Mappemonde"), 2);
 	moduleE->addItem(tr("Combat"), 3);
+
+	connect(moduleE, SIGNAL(currentIndexChanged(int)), SLOT(setPosPresetsVisibilityFromModuleIndex(int)));
 
 	mapE = new QComboBox(positionGBE);
 	mapE->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
@@ -172,4 +185,35 @@ void PartyEditor::savePage()
 	data->misc2.location = mapE->itemData(mapE->currentIndex()).toInt();
 	data->misc2.location_last = lastMapE->itemData(lastMapE->currentIndex()).toInt();
 
+}
+
+void PartyEditor::setPosPresetFromIndex(int index)
+{
+	if (index == 0) {
+		return;
+	}
+
+	qint32 data = presetPosE->itemData(index).toInt(),
+	        data2 = presetPosE->itemData(index, Qt::UserRole + 1).toInt(),
+	        x = data & 0xFFFF, y = (data >> 16) & 0xFFFF,
+	        z = data2 & 0xFFFF, dir = (data2 >> 16) & 0xFFFF;
+
+	xE.first()->setValue(x);
+	yE.first()->setValue(y);
+	idE.first()->setValue(z);
+	dirE.first()->setValue(dir);
+
+	for (int i=1 ; i < xE.size(); ++i) {
+		xE.at(i)->setValue(0);
+		yE.at(i)->setValue(0);
+		idE.at(i)->setValue(0);
+		dirE.at(i)->setValue(0);
+	}
+
+	presetPosE->setCurrentIndex(0);
+}
+
+void PartyEditor::setPosPresetsVisibilityFromModuleIndex(int index)
+{
+	presetPosE->setVisible(index == 2);
 }

--- a/PageWidgets/PartyEditor.h
+++ b/PageWidgets/PartyEditor.h
@@ -31,13 +31,15 @@ public:
 public slots:
 	void fillPage();
 	void savePage();
+	void setPosPresetFromIndex(int index);
+	void setPosPresetsVisibilityFromModuleIndex(int index);
 protected:
 	void buildWidget();
 private:
 	QList<QComboBox *> partyE, partySortE;
 	QCheckBox *dreamE;
 	QList<QSpinBox *> xE, yE, idE, dirE;
-	QComboBox *moduleE, *mapE, *lastMapE;
+	QComboBox *moduleE, *mapE, *lastMapE, *presetPosE;
 };
 
 #endif // DEF_PARTYEDITOR

--- a/PageWidgets/TTriadEditor.cpp
+++ b/PageWidgets/TTriadEditor.cpp
@@ -302,8 +302,7 @@ QWidget *TTriadEditor::buildPage2()
 
 	queenE = new QComboBox(group3);
 	queenE->addItem(tr("Nulle part"), 0);
-	QStringList queenCities;
-	queenCities << tr("Balamb City") << tr("Deling City") << tr("Shumi village") << tr("Winhill") << tr("Dollet") << tr("Horizon") << tr("Lunar Gate") << tr("Esthar City");
+	QStringList queenCities = Data::cities().list().mid(0, 8);
 	i=1;
 	foreach(const QString &queenCity, queenCities)
 		queenE->addItem(queenCity, i++);

--- a/PageWidgets/TTriadEditor.cpp
+++ b/PageWidgets/TTriadEditor.cpp
@@ -37,7 +37,7 @@ void TTriadEditor::buildWidget()
 
 	tabWidget = new QTabWidget(this);
 	tabWidget->addTab(buildPage1(), tr("Cartes"));
-	tabWidget->addTab(buildPage2(), tr("Règles"));
+	tabWidget->addTab(buildPage2(), tr("Règles et quêtes"));
 
 	layout->addWidget(tabWidget);
 	layout->setContentsMargins(QMargins());
@@ -275,85 +275,112 @@ QWidget *TTriadEditor::buildPage2()
 	}
 	group2L->addStretch(1);
 
-	QGroupBox *group3 = new QGroupBox(tr("Divers"), ret);
+	QGroupBox *group3 = new QGroupBox(tr("Quêtes"), ret);
 	QGridLayout *group3L = new QGridLayout(group3);
 
+	regions.prepend(tr("Aucune"));
+
 	last_regionE = new QComboBox(group3);
-	last_regionE->addItem(QString::number(0), 0);
-	int i=1;
+	int i=0;
 	foreach(const QString &region, regions)
 		last_regionE->addItem(region, i++);
 
 	last2_regionE = new QComboBox(group3);
-	last2_regionE->addItem(QString::number(0), 0);
-	i=1;
+	i=0;
 	foreach(const QString &region, regions)
 		last2_regionE->addItem(region, i++);
 
+	QStringList cc_names;
+	cc_names << tr("-") << tr("Valet") << tr("Trèfle") << tr("Carreaux") << tr("Pique") << tr("Reine de coeur");
+	QList<int> cc_values;
+	cc_values << 0 << 0x1 << 0x3 << 0x13 << 0x17 << 0x1F;
+
+	ccE = new QComboBox(group3);
+	i=0;
+	foreach(const QString &name, cc_names)
+		ccE->addItem(name, cc_values.at(i++));
+
 	queenE = new QComboBox(group3);
-	queenE->addItem(QString::number(0), 0);
+	queenE->addItem(tr("Nulle part"), 0);
 	QStringList queenCities;
 	queenCities << tr("Balamb City") << tr("Deling City") << tr("Shumi village") << tr("Winhill") << tr("Dollet") << tr("Horizon") << tr("Lunar Gate") << tr("Esthar City");
 	i=1;
 	foreach(const QString &queenCity, queenCities)
 		queenE->addItem(queenCity, i++);
 
+	traderule_queenE = new QComboBox(group3);
+
+	i=0;
+	foreach(const QString &name, traderules_names)
+		traderule_queenE->addItem(name, i++);
+
 	traderatingE = new SpinBox8(group3);
 	traderating_regionE = new QComboBox(group3);
-	traderating_regionE->addItem(QString::number(0), 0);
-	i=1;
+	i=0;
 	foreach(const QString &region, regions)
 		traderating_regionE->addItem(region, i++);
-
-	ttvictorycountE = new SpinBox16(group3);
-	ttdefeatcountE = new SpinBox16(group3);
-	ttegalitycountE = new SpinBox16(group3);
 
 	ttdegenerationE = new SpinBox8(group3);
 
 	ttcardqueenquestE = new QComboBox(group3);
-	ttcardqueenquestE->addItem(tr("MiniMog"), 0);
-	ttcardqueenquestE->addItem(tr("Tauros"), 1);
-	ttcardqueenquestE->addItem(tr("Chicobo"), 2);
-	ttcardqueenquestE->addItem(tr("Alexander"), 3);
+	ttcardqueenquestE->addItem(tr("Aucune"), 0);
+	ttcardqueenquestE->addItem(tr("Kiros"), 1);
+	ttcardqueenquestE->addItem(tr("Irvine"), 2);
+	ttcardqueenquestE->addItem(tr("GroChocobo"), 3);
 	ttcardqueenquestE->addItem(tr("Helltrain"), 4);
-	ttcardqueenquestE->addItem(tr("Toutes"), 5);
-
-	unknown1E_label = new QLabel(tr("Inconnu 1 :"),group3);
-	unknown1E = new SpinBox16(group3);
-	unknown2E_label = new QLabel(tr("Inconnu 2 :"),group3);
-	unknown2E = new SpinBox32(group3);
+	ttcardqueenquestE->addItem(tr("Phénix"), 5);
 
 	group3L->addWidget(new QLabel(tr("Dernières régions visitées :"),group3), 0, 0);
 	group3L->addWidget(last_regionE, 0, 1);
-	group3L->addWidget(last2_regionE, 0, 2);
+	group3L->addWidget(last2_regionE, 1, 1);
+	group3L->addWidget(new QLabel(tr("Quête du Groupe CC :"),group3), 0, 2);
+	group3L->addWidget(ccE, 0, 3);
 	group3L->addWidget(new QLabel(tr("Emplacement reine des cartes :"),group3), 2, 0);
 	group3L->addWidget(queenE, 2, 1);
+	group3L->addWidget(new QLabel(tr("Règle du vainqueur de la reine :"),group3), 2, 2);
+	group3L->addWidget(traderule_queenE, 2, 3);
 	group3L->addWidget(new QLabel(tr("Nombre de joueurs règle du vainqueur :"),group3), 3, 0);
 	group3L->addWidget(traderatingE, 3, 1);
-	group3L->addWidget(new QLabel(tr("Région :"),group3), 3, 2);
+	group3L->addWidget(new QLabel(tr("Région règle du vainqueur :"),group3), 3, 2);
 	group3L->addWidget(traderating_regionE, 3, 3);
 	group3L->addWidget(new QLabel(tr("Dégénération :"),group3), 4, 0);
 	group3L->addWidget(ttdegenerationE, 4, 1);
-	group3L->addWidget(new QLabel(tr("Cartes créées :"),group3), 4, 2);
+	group3L->addWidget(new QLabel(tr("Dernière carte créée :"),group3), 4, 2);
 	group3L->addWidget(ttcardqueenquestE, 4, 3);
-	group3L->addWidget(new QLabel(tr("Nombre de victoires :"),group3), 5, 0);
-	group3L->addWidget(ttvictorycountE, 5, 1);
-	group3L->addWidget(new QLabel(tr("Nombre de défaites :"),group3), 5, 2);
-	group3L->addWidget(ttdefeatcountE, 5, 3);
-	group3L->addWidget(new QLabel(tr("Nombre d'égalités :"),group3), 6, 0);
-	group3L->addWidget(ttegalitycountE, 6, 1);
-	group3L->addWidget(unknown1E_label, 7, 0);
-	group3L->addWidget(unknown1E, 7, 1);
-	group3L->addWidget(unknown2E_label, 7, 2);
-	group3L->addWidget(unknown2E, 7, 3);
+
+	QGroupBox *group4 = new QGroupBox(tr("Divers"), ret);
+	QGridLayout *group4L = new QGridLayout(group4);
+
+	ttvictorycountE = new SpinBox16(group4);
+	ttdefeatcountE = new SpinBox16(group4);
+	ttegalitycountE = new SpinBox16(group4);
+	ttbguvictorycountE = new SpinBox8(group4);
+
+	unknown1E_label = new QLabel(tr("Inconnu 1 :"),group4);
+	unknown1E = new SpinBox16(group4);
+	unknown2E_label = new QLabel(tr("Inconnu 2 :"),group4);
+	unknown2E = new SpinBox32(group4);
+
+	group4L->addWidget(new QLabel(tr("Nombre de victoires :"),group4), 0, 0);
+	group4L->addWidget(ttvictorycountE, 0, 1);
+	group4L->addWidget(new QLabel(tr("Nombre de défaites :"),group4), 0, 2);
+	group4L->addWidget(ttdefeatcountE, 0, 3);
+	group4L->addWidget(new QLabel(tr("Nombre d'égalités :"),group4), 0, 4);
+	group4L->addWidget(ttegalitycountE, 0, 5);
+	group4L->addWidget(new QLabel(tr("Nombre de victoires à la BGU :"),group4), 1, 0);
+	group4L->addWidget(ttbguvictorycountE, 1, 1);
+	group4L->addWidget(unknown1E_label, 1, 2);
+	group4L->addWidget(unknown1E, 1, 3);
+	group4L->addWidget(unknown2E_label, 1, 4);
+	group4L->addWidget(unknown2E, 1, 5);
 
 	QGridLayout *layout = new QGridLayout(ret);
 	layout->addWidget(ruleE_list, 0, 0);
 	layout->addWidget(group1, 0, 1);
 	layout->addWidget(group2, 0, 2);
 	layout->addWidget(group3, 1, 0, 1, 4);
-	layout->setRowStretch(2, 1);
+	layout->addWidget(group4, 2, 0, 1, 4);
+	layout->setRowStretch(3, 1);
 	layout->setColumnStretch(3, 1);
 
 	return ret;
@@ -389,11 +416,14 @@ void TTriadEditor::fillPage()
 	setCurrentIndex(last_regionE, data->field.tt_lastregion[0]);
 	setCurrentIndex(last2_regionE, data->field.tt_lastregion[1]);
 	setCurrentIndex(queenE, data->field.tt_cardqueen_location);
+	setCurrentIndex(traderule_queenE, data->field.tt_curtraderulequeen);
+	setCurrentIndex(ccE, data->field.tt_cc_quest);
 	traderatingE->setValue(data->field.tt_traderating);
 	setCurrentIndex(traderating_regionE, data->field.tt_traderating_region);
 	ttvictorycountE->setValue(data->ttcards.tt_victory_count);
 	ttdefeatcountE->setValue(data->ttcards.tt_defeat_count);
 	ttegalitycountE->setValue(data->ttcards.tt_egality_count);
+	ttbguvictorycountE->setValue(data->field.tt_bgu_victory_count);
 	ttdegenerationE->setValue(data->field.tt_degeneration);
 	setCurrentIndex(ttcardqueenquestE, data->field.tt_cardqueen_quest);
 	unknown1E->setValue(data->ttcards.u2);
@@ -453,18 +483,21 @@ void TTriadEditor::savePage()
 		}
 	}
 	saveRules(ruleE_list->currentRow());
-	data->field.tt_lastregion[0] = last_regionE->itemData(last_regionE->currentIndex()).toInt();
-	data->field.tt_lastregion[1] = last2_regionE->itemData(last2_regionE->currentIndex()).toInt();
-	data->field.tt_cardqueen_location = queenE->itemData(queenE->currentIndex()).toInt();
-	data->field.tt_traderating = traderatingE->value();
-	data->field.tt_traderating_region = traderating_regionE->itemData(traderating_regionE->currentIndex()).toInt();
-	data->ttcards.tt_victory_count = ttvictorycountE->value();
-	data->ttcards.tt_defeat_count = ttdefeatcountE->value();
-	data->ttcards.tt_egality_count = ttegalitycountE->value();
-	data->field.tt_degeneration = ttdegenerationE->value();
-	data->field.tt_cardqueen_quest = ttcardqueenquestE->itemData(ttcardqueenquestE->currentIndex()).toInt();
-	data->ttcards.u2 = unknown1E->value();
-	data->ttcards.u3 = unknown2E->value();
+	data->field.tt_lastregion[0] = quint8(last_regionE->itemData(last_regionE->currentIndex()).toInt());
+	data->field.tt_lastregion[1] = quint8(last2_regionE->itemData(last2_regionE->currentIndex()).toInt());
+	data->field.tt_cardqueen_location = quint8(queenE->itemData(queenE->currentIndex()).toInt());
+	data->field.tt_cc_quest = quint8(ccE->itemData(ccE->currentIndex()).toInt());
+	data->field.tt_curtraderulequeen = quint8(traderule_queenE->itemData(traderule_queenE->currentIndex()).toInt());
+	data->field.tt_traderating = quint8(traderatingE->value());
+	data->field.tt_traderating_region = quint8(traderating_regionE->itemData(traderating_regionE->currentIndex()).toInt());
+	data->ttcards.tt_victory_count = quint16(ttvictorycountE->value());
+	data->ttcards.tt_defeat_count = quint16(ttdefeatcountE->value());
+	data->ttcards.tt_egality_count = quint16(ttegalitycountE->value());
+	data->field.tt_bgu_victory_count = quint8(ttbguvictorycountE->value());
+	data->field.tt_degeneration = quint8(ttdegenerationE->value());
+	data->field.tt_cardqueen_quest = quint8(ttcardqueenquestE->itemData(ttcardqueenquestE->currentIndex()).toInt());
+	data->ttcards.u2 = quint16(unknown1E->value());
+	data->ttcards.u3 = quint16(unknown2E->value());
 }
 
 void TTriadEditor::saveRules(int id)

--- a/PageWidgets/TTriadEditor.h
+++ b/PageWidgets/TTriadEditor.h
@@ -57,8 +57,8 @@ private:
 	QLabel *cardPreview;
 	// Page 2
 	QListWidget *ruleE_list;
-	QComboBox *queenE, *last_regionE, *last2_regionE, *traderating_regionE, *ttcardqueenquestE;
-	SpinBox8 *traderatingE, *ttdegenerationE;
+	QComboBox *ccE, *queenE, *traderule_queenE, *last_regionE, *last2_regionE, *traderating_regionE, *ttcardqueenquestE;
+	SpinBox8 *traderatingE, *ttdegenerationE, *ttbguvictorycountE;
 	SpinBox16 *ttvictorycountE, *ttdefeatcountE, *ttegalitycountE;
 	SpinBox32 *unknown2E;
 	SpinBox16 *unknown1E;

--- a/SaveData.h
+++ b/SaveData.h
@@ -42,7 +42,7 @@
 #endif
 
 #define GF_GET_FORGOTTEN(data) \
-	((data).forgotten1 | ((data).forgotten2 << 8) | ((data).forgotten3 << 16))
+	quint32((data).forgotten1 | ((data).forgotten2 << 8) | ((data).forgotten3 << 16))
 
 #define GF_SET_FORGOTTEN(data, forgotten)			\
 	(data).forgotten1 = forgotten & 0xFF;				\
@@ -63,8 +63,8 @@ struct GFORCES//68
 	quint16 KOs;
 	quint8 learning;
 	quint8 forgotten1;// 22 + 2 unused
-	quint8 forgotten2;// 22 + 2 unused
-	quint8 forgotten3;// 22 + 2 unused
+	quint8 forgotten2;
+	quint8 forgotten3;
 });
 
 PACK(
@@ -186,7 +186,7 @@ struct ITEMS//428
 PACK(
 struct MISC2//144
 {
-	quint32 game_time;
+    quint32 game_time; // var75 (in battle scripts)
 	quint32 countdown;
 	// Battle vars (75)
 	quint32 u1;
@@ -279,25 +279,33 @@ struct FIELD//1024
 {
 	quint16 game_moment;// var256 in field scripts
 	quint8 ward_unused;// unused text at gpbigin2
-	quint8 u1[2];
+	quint8 unused1[2];
 	quint8 save_flag;
-	quint8 u2[10];
+	quint8 unused2[2];
+	quint8 wm_related[7];
+	quint8 unused3;
 	quint8 tt_rules[8];
 	quint8 tt_traderules[8];
 	quint8 tt_lastrules[2];
 	quint8 tt_lastregion[2];
-	quint8 u3;// Unused in save
-	quint8 tt_currules;// Unused in save
-	quint8 tt_curtraderule;// Unused in save
+	quint8 tt_new_rules_tmp;// Unused in save
+	quint8 tt_new_trade_rules_tmp;// Unused in save
+	quint8 tt_add_this_rule_queen_tmp;// Unused in save
 	quint8 tt_cardqueen_location;
 	quint8 tt_traderating_region;
 	quint8 tt_traderating;
 	quint8 tt_degeneration;
 	quint8 tt_curtraderulequeen;
 	quint8 tt_cardqueen_quest;
-	quint8 u4[3];
-	quint16 timber_maniacs;
-	quint8 u7[974];//			(4285=tt club cc|4286=tt victory count BGU)
+	quint8 unused4[3];
+	quint16 timber_maniacs; // var304 in field scripts
+	quint8 u1[168];
+	quint8 tt_players_bgu_dialogs1; // first cards BGU|CC Ragnarok init CD4|CC Ragnarok Joker|CC Ragnarok Quistis
+	quint8 tt_players_bgu_dialogs2; // kadowaki 1|kadowaki 2|joker in prison|joker BGU|joker BGU CC|dormitory to Quistis night|Zell with cards
+	quint8 tt_players_bgu_dialogs3; // CC Jack 1|CC Jack 2|CC Clover about Jack|CC Diamonds|CC Spades|CC Shu|Nida about Shu in CC|Running Child is alive!
+	quint8 tt_cc_quest; // Jack | Clover | Spades | Shu | Diamonds
+	quint8 tt_bgu_victory_count;
+	quint8 u2[801];
 });
 
 PACK(

--- a/SavecardData.h
+++ b/SavecardData.h
@@ -28,7 +28,7 @@ class SavecardData
 {
 public:
 	enum Type {
-		Pc, Ps, Vgs, Gme, Vmp, Psv, PcSlot, Unknown, Undefined
+		Pc, PcUncompressed, Ps, Vgs, Gme, Vmp, Psv, PcSlot, Unknown, Undefined
 	};
 
 	explicit SavecardData(const QString &path, quint8 slot=0, const FF8Installation &ff8Installation=FF8Installation());
@@ -51,7 +51,7 @@ public:
 	void moveSave(int sourceID, int targetID);
 	SaveData *getSave(int id) const;
 	int saveCount() const;
-	bool save2PC(const quint8 id, const QString &saveAs);
+	bool save2PC(const quint8 id, const QString &saveAs, bool compress);
 	bool save2PSV(const quint8 id, const QString &saveAs, const QByteArray &MCHeader);
 	bool save2PS(const QList<int> &ids, const QString &path, const Type newType, const QByteArray &MCHeader);
 	bool saveDirectory();

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,14 @@
-hyne (1.9.2) precise; urgency=low
+hyne (1.10.0) precise; urgency=low
+
+  * Fixing slot detection on modern Windows (2000 version)
+  * Adding uncompressed save format
+  * Fixing GF forget ability
+  * Adding Queen trade rule, CC quest and BGU TT victory count
+  * Adding worldmap position presets
+
+ -- Jérôme Arzel <myst6re@gmail.com> Sat, 30 Nov 2019 22:46:13 +0200
+
+hyne (1.9.3) precise; urgency=low
 
   * Adding button to set character bonuses to max
   * Fix compilation errors with Qt 5.10

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,15 @@
 hyne (1.9.2) precise; urgency=low
 
+  * Adding button to set character bonuses to max
+  * Fix compilation errors with Qt 5.10
+  * Drop Qt 4 compatibility
+  * Clean target specific meta generation (RC file on Windows and Bundle on Mac OSX)
+  * Fix version in Mac OSX Bundle
+
+ -- Jérôme Arzel <myst6re@gmail.com> Sun, 14 Oct 2018 00:55:10 +0200
+
+hyne (1.9.2) precise; urgency=low
+
   * Adding *.srm file support
   * Fixing Characters Abilities page: abilities were always cleared
 

--- a/deploy.bat
+++ b/deploy.bat
@@ -25,4 +25,4 @@ rem Deploy Exe
 xcopy /y %EXE_PATH% %OUTPUT_DIR%
 
 rem Compress Exe and DLLs. Note: DLLs in platforms/ directory should not be compressed.
-upx %OUTPUT_DIR%\*.dll %OUTPUT_DIR%\Hyne.exe
+rem upx %OUTPUT_DIR%\*.dll %OUTPUT_DIR%\Hyne.exe

--- a/hyne_en.ts
+++ b/hyne_en.ts
@@ -1978,59 +1978,64 @@ By default Hyne attempts to automatically sign saves, but in case of error, you 
     </message>
     <message>
         <location filename="PageWidgets/PartyEditor.cpp" line="65"/>
+        <source>Position prédéfinie</source>
+        <translation>Presets</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/PartyEditor.cpp" line="76"/>
         <source>X :</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="66"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="77"/>
         <source>Y :</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="67"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="78"/>
         <source>Triangle ID :</source>
         <translation>Triangle ID:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="68"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="79"/>
         <source>Direction :</source>
         <translation>Direction:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="72"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="83"/>
         <source>Membre %1 :</source>
         <translation>Member %1:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="90"/>
-        <location filename="PageWidgets/PartyEditor.cpp" line="91"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="101"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="102"/>
         <source>Terrain</source>
         <translation>Field</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="92"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="103"/>
         <source>Mappemonde</source>
         <translation>Worldmap</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="93"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="104"/>
         <source>Combat</source>
         <translation>Battle</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="111"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="124"/>
         <source>Terrain courant</source>
         <translation>Current field</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="113"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="126"/>
         <source>Terrain précédent</source>
         <translation>Previous field</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="141"/>
-        <location filename="PageWidgets/PartyEditor.cpp" line="148"/>
-        <location filename="PageWidgets/PartyEditor.cpp" line="155"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="154"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="161"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="168"/>
         <source>Inconnu (%1)</source>
         <translation>Unknown (%1)</translation>
     </message>
@@ -2531,2175 +2536,2175 @@ By default Hyne attempts to automatically sign saves, but in case of error, you 
 <context>
     <name>QObject</name>
     <message>
-        <location filename="Data.cpp" line="41"/>
+        <location filename="Data.cpp" line="42"/>
         <source>Vgr-A</source>
         <translation>Str-J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="41"/>
+        <location filename="Data.cpp" line="42"/>
         <source>Dfs-A</source>
         <translation>Vit-J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="41"/>
+        <location filename="Data.cpp" line="42"/>
         <source>Mgi-A</source>
         <translation>Mag-J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="41"/>
+        <location filename="Data.cpp" line="42"/>
         <source>Psy-A</source>
         <translation>Spr-J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="41"/>
+        <location filename="Data.cpp" line="42"/>
         <source>HP-A</source>
         <translation>HP-J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="42"/>
+        <location filename="Data.cpp" line="43"/>
         <source>Vts-A</source>
         <translation>Spd-J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="42"/>
+        <location filename="Data.cpp" line="43"/>
         <source>Esq-A</source>
         <translation>Eva-J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="42"/>
+        <location filename="Data.cpp" line="43"/>
         <source>Prc-A</source>
         <translation>Hit-J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="42"/>
+        <location filename="Data.cpp" line="43"/>
         <source>Chc-A</source>
         <translation>Luck-J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="42"/>
+        <location filename="Data.cpp" line="43"/>
         <source>Atq-Élé-A</source>
         <translation>Elem-Atk-J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="43"/>
+        <location filename="Data.cpp" line="44"/>
         <source>Atq-Mtl-A</source>
         <translation>ST-Atk-J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="43"/>
+        <location filename="Data.cpp" line="44"/>
         <source>Déf-Élé-A</source>
         <translation>Elem-Def-J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="43"/>
+        <location filename="Data.cpp" line="44"/>
         <source>Déf-Mtl-A</source>
         <translation>ST-Def-J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="43"/>
+        <location filename="Data.cpp" line="44"/>
         <source>Déf-ÉléX2</source>
         <translation>Elem-Defx2</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="43"/>
+        <location filename="Data.cpp" line="44"/>
         <source>Déf-ÉléX4</source>
         <translation>Elem-Defx4</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="44"/>
+        <location filename="Data.cpp" line="45"/>
         <source>Déf-Mtl-Ax2</source>
         <translation>ST-Def-Jx2</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="44"/>
+        <location filename="Data.cpp" line="45"/>
         <source>Déf-Mtl-Ax4</source>
         <translation>ST-Def-Jx4</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="44"/>
+        <location filename="Data.cpp" line="45"/>
         <source>CapacitéX3</source>
         <translation>Abilityx3</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="44"/>
+        <location filename="Data.cpp" line="45"/>
         <source>CapacitéX4</source>
         <translation>Abilityx4</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="44"/>
+        <location filename="Data.cpp" line="45"/>
         <source>Magie</source>
         <translation>Magic</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="45"/>
+        <location filename="Data.cpp" line="46"/>
         <source>G-Force</source>
         <translation>GF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="45"/>
+        <location filename="Data.cpp" line="46"/>
         <source>Voler</source>
         <translation>Draw</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="45"/>
+        <location filename="Data.cpp" line="46"/>
         <source>Objets</source>
         <translation>Item</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="45"/>
+        <location filename="Data.cpp" line="46"/>
         <source>Carte</source>
         <translation>Card</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="46"/>
+        <location filename="Data.cpp" line="47"/>
         <source>Châtiment</source>
         <translation>Doom</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="46"/>
+        <location filename="Data.cpp" line="47"/>
         <source>Mad Rush</source>
         <translation>Mad Rush</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="46"/>
+        <location filename="Data.cpp" line="47"/>
         <source>Traitement</source>
         <translation>Treatment</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="46"/>
+        <location filename="Data.cpp" line="47"/>
         <source>Défense</source>
         <translation>Defend</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="46"/>
+        <location filename="Data.cpp" line="47"/>
         <source>Combustion</source>
         <translation>Darkside</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="47"/>
+        <location filename="Data.cpp" line="48"/>
         <source>Arnica</source>
         <translation>Recover</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="47"/>
+        <location filename="Data.cpp" line="48"/>
         <source>Phagocyte</source>
         <translation>Absorb</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="47"/>
+        <location filename="Data.cpp" line="48"/>
         <source>Ranimer</source>
         <translation>Revive</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="47"/>
+        <location filename="Data.cpp" line="48"/>
         <source>Nv Moins</source>
         <translation>LV Down</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="47"/>
+        <location filename="Data.cpp" line="48"/>
         <source>Nv Plus</source>
         <translation>LV Up</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="48"/>
+        <location filename="Data.cpp" line="49"/>
         <source>Kamikaze</source>
         <translation>Kamikaze</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="48"/>
+        <location filename="Data.cpp" line="49"/>
         <source>Cannibale</source>
         <translation>Devour</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="48"/>
+        <location filename="Data.cpp" line="49"/>
         <source>Mini Kikou</source>
         <translation>MiniMog</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="48"/>
+        <location filename="Data.cpp" line="49"/>
         <source>HP+20%</source>
         <translation>HP+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="48"/>
+        <location filename="Data.cpp" line="49"/>
         <source>HP+40%</source>
         <translation>HP+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="49"/>
+        <location filename="Data.cpp" line="50"/>
         <source>HP+80%</source>
         <translation>HP+80%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="49"/>
+        <location filename="Data.cpp" line="50"/>
         <source>Vgr+20%</source>
         <translation>Str+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="49"/>
+        <location filename="Data.cpp" line="50"/>
         <source>Vgr+40%</source>
         <translation>Str+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="49"/>
+        <location filename="Data.cpp" line="50"/>
         <source>Vgr+60%</source>
         <translation>Str+60%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="49"/>
+        <location filename="Data.cpp" line="50"/>
         <source>Dfs+20%</source>
         <translation>Vit+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="50"/>
+        <location filename="Data.cpp" line="51"/>
         <source>Dfs+40%</source>
         <translation>Vit+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="50"/>
+        <location filename="Data.cpp" line="51"/>
         <source>Dfs+60%</source>
         <translation>Vit+60%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="50"/>
+        <location filename="Data.cpp" line="51"/>
         <source>Mgi+20%</source>
         <translation>Mag+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="50"/>
+        <location filename="Data.cpp" line="51"/>
         <source>Mgi+40%</source>
         <translation>Mag+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="50"/>
+        <location filename="Data.cpp" line="51"/>
         <source>Mgi+60%</source>
         <translation>Mag+60%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="51"/>
+        <location filename="Data.cpp" line="52"/>
         <source>Psy+20%</source>
         <translation>Spr+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="51"/>
+        <location filename="Data.cpp" line="52"/>
         <source>Psy+40%</source>
         <translation>Spr+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="51"/>
+        <location filename="Data.cpp" line="52"/>
         <source>Psy+60%</source>
         <translation>Spr+60%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="51"/>
+        <location filename="Data.cpp" line="52"/>
         <source>Vit+20%</source>
         <translation>Spd+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="51"/>
+        <location filename="Data.cpp" line="52"/>
         <source>Vit+40%</source>
         <translation>Spd+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="52"/>
+        <location filename="Data.cpp" line="53"/>
         <source>Esq+30%</source>
         <translation>Eva+30%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="52"/>
+        <location filename="Data.cpp" line="53"/>
         <source>Chc+50%</source>
         <translation>Luck+50%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="52"/>
+        <location filename="Data.cpp" line="53"/>
         <source>Piller</source>
         <translation>Mug</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="52"/>
+        <location filename="Data.cpp" line="53"/>
         <source>Schweitzer</source>
         <translation>Med Data</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="52"/>
+        <location filename="Data.cpp" line="53"/>
         <source>Amorce</source>
         <translation>Counter</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="53"/>
+        <location filename="Data.cpp" line="54"/>
         <source>Backlash</source>
         <translation>Return Damage</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="53"/>
+        <location filename="Data.cpp" line="54"/>
         <source>Empathie</source>
         <translation>Cover</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="53"/>
+        <location filename="Data.cpp" line="54"/>
         <source>Genki</source>
         <translation>Initiative</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="53"/>
+        <location filename="Data.cpp" line="54"/>
         <source>Atlas-HP</source>
         <translation>Move-HP Up</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="54"/>
+        <location filename="Data.cpp" line="55"/>
         <source>Auto-Carapace</source>
         <translation>Auto-Protect</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="55"/>
+        <location filename="Data.cpp" line="56"/>
         <source>Auto-Blindage</source>
         <translation>Auto-Shell</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="55"/>
+        <location filename="Data.cpp" line="56"/>
         <source>Auto-Boomerang</source>
         <translation>Auto-Reflect</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="55"/>
+        <location filename="Data.cpp" line="56"/>
         <source>Auto-Booster</source>
         <translation>Auto-Haste</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="55"/>
+        <location filename="Data.cpp" line="56"/>
         <source>Auto-Potion</source>
         <translation>Auto-Potion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="55"/>
+        <location filename="Data.cpp" line="56"/>
         <source>DoublEco</source>
         <translation>Expendx2-1</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="56"/>
+        <location filename="Data.cpp" line="57"/>
         <source>TriplEco</source>
         <translation>Expendx3-1</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="56"/>
+        <location filename="Data.cpp" line="57"/>
         <source>Prudence</source>
         <translation>Alert</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="56"/>
+        <location filename="Data.cpp" line="57"/>
         <source>Clairvoyance</source>
         <translation>Move-Find</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="56"/>
+        <location filename="Data.cpp" line="57"/>
         <source>Mi-Combat</source>
         <translation>Enc-Half</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="56"/>
+        <location filename="Data.cpp" line="57"/>
         <source>Freud</source>
         <comment>ability</comment>
         <translation>Ribbon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="57"/>
+        <location filename="Data.cpp" line="58"/>
         <source>No-Combat</source>
         <translation>Enc-None</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="57"/>
+        <location filename="Data.cpp" line="58"/>
         <source>Sensor</source>
         <translation>Rare Item</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="57"/>
+        <location filename="Data.cpp" line="58"/>
         <source>Invoc+10%</source>
         <translation>SumMag+10%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="57"/>
+        <location filename="Data.cpp" line="58"/>
         <source>Invoc+20%</source>
         <translation>SumMag+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="57"/>
+        <location filename="Data.cpp" line="58"/>
         <source>Invoc+30%</source>
         <translation>SumMag+30%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="58"/>
+        <location filename="Data.cpp" line="59"/>
         <source>Invoc+40%</source>
         <translation>SumMag+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="58"/>
+        <location filename="Data.cpp" line="59"/>
         <source>HP-GF+10%</source>
         <translation>GFHP+10%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="58"/>
+        <location filename="Data.cpp" line="59"/>
         <source>HP-GF+20%</source>
         <translation>GFHP+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="58"/>
+        <location filename="Data.cpp" line="59"/>
         <source>HP-GF+30%</source>
         <translation>GFHP+30%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="58"/>
+        <location filename="Data.cpp" line="59"/>
         <source>HP-GF+40%</source>
         <translation>GFHP+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="59"/>
+        <location filename="Data.cpp" line="60"/>
         <source>Turbo</source>
         <translation>Boost</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="59"/>
+        <location filename="Data.cpp" line="60"/>
         <source>Souk</source>
         <translation>Haggle</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="59"/>
+        <location filename="Data.cpp" line="60"/>
         <source>Sentier</source>
         <translation>Sell-High</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="59"/>
+        <location filename="Data.cpp" line="60"/>
         <source>Connaisseur</source>
         <translation>Familiar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="59"/>
+        <location filename="Data.cpp" line="60"/>
         <source>Boutiques</source>
         <translation>Call Shop</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="60"/>
+        <location filename="Data.cpp" line="61"/>
         <source>Bazars</source>
         <translation>Junk Shop</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="60"/>
+        <location filename="Data.cpp" line="61"/>
         <source>Créa-Mgi-Cél</source>
         <translation>T Mag-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="60"/>
+        <location filename="Data.cpp" line="61"/>
         <source>Créa-Mgi-Gla</source>
         <translation>I Mag-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="60"/>
+        <location filename="Data.cpp" line="61"/>
         <source>Créa-Mgi-Inc</source>
         <translation>F Mag-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="60"/>
+        <location filename="Data.cpp" line="61"/>
         <source>Créa-Mgi-Méd</source>
         <translation>L Mag-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="61"/>
+        <location filename="Data.cpp" line="62"/>
         <source>Créa-Mgi-Temp</source>
         <translation>Time Mag-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="61"/>
+        <location filename="Data.cpp" line="62"/>
         <source>Créa-Mgi-Mtl</source>
         <translation>ST Mag-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="61"/>
+        <location filename="Data.cpp" line="62"/>
         <source>Créa-Mgi-Pro</source>
         <translation>Supt Mag-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="61"/>
+        <location filename="Data.cpp" line="62"/>
         <source>Créa-Mgi-Tab</source>
         <translation>Forbid Mag-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="61"/>
+        <location filename="Data.cpp" line="62"/>
         <source>Créa-Mgi-Thér</source>
         <translation>Recov Med-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="62"/>
+        <location filename="Data.cpp" line="63"/>
         <source>Créa-Mgi-Ana</source>
         <translation>ST Med-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="62"/>
+        <location filename="Data.cpp" line="63"/>
         <source>Créa-Balles</source>
         <translation>Ammo-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="62"/>
+        <location filename="Data.cpp" line="63"/>
         <source>Créa-Outils</source>
         <translation>Tool-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="62"/>
+        <location filename="Data.cpp" line="63"/>
         <source>Créa-Thér-Tab</source>
         <translation>Forbid Med-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="62"/>
+        <location filename="Data.cpp" line="63"/>
         <source>Créa-Thér-GF</source>
         <translation>GFRecov Med-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="63"/>
+        <location filename="Data.cpp" line="64"/>
         <source>Créa-Capa-GF</source>
         <translation>GFAbl Med-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="63"/>
+        <location filename="Data.cpp" line="64"/>
         <source>Créa-Mgi-Plus</source>
         <translation>Mid Mag-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="63"/>
+        <location filename="Data.cpp" line="64"/>
         <source>Créa-Mgi-Max</source>
         <translation>High Mag-RF</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="63"/>
+        <location filename="Data.cpp" line="64"/>
         <source>Soins NV +</source>
         <translation>Med LV Up</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="63"/>
+        <location filename="Data.cpp" line="64"/>
         <source>Mode Carte</source>
         <translation>Card Mod</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="68"/>
+        <location filename="Data.cpp" line="69"/>
         <source>Brasier</source>
         <translation>Fire</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="68"/>
+        <location filename="Data.cpp" line="69"/>
         <source>Brasier+</source>
         <translation>Fira</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="68"/>
+        <location filename="Data.cpp" line="69"/>
         <source>BrasierX</source>
         <translation>Firaga</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="68"/>
+        <location filename="Data.cpp" line="69"/>
         <source>Glacier</source>
         <translation>Blizzard</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="68"/>
+        <location filename="Data.cpp" line="69"/>
         <source>Glacier+</source>
         <translation>Blizzara</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="69"/>
+        <location filename="Data.cpp" line="70"/>
         <source>GlacierX</source>
         <translation>Blizzaga</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="69"/>
+        <location filename="Data.cpp" line="70"/>
         <source>Foudre</source>
         <translation>Thunder</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="69"/>
+        <location filename="Data.cpp" line="70"/>
         <source>Foudre+</source>
         <translation>Thundara</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="69"/>
+        <location filename="Data.cpp" line="70"/>
         <source>FoudreX</source>
         <translation>Thundaga</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="69"/>
+        <location filename="Data.cpp" line="70"/>
         <source>Rafale</source>
         <translation>Aero</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="69"/>
+        <location filename="Data.cpp" line="70"/>
         <source>Cyanure</source>
         <translation>Bio</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="70"/>
+        <location filename="Data.cpp" line="71"/>
         <source>Quart</source>
         <translation>Demi</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="70"/>
+        <location filename="Data.cpp" line="71"/>
         <source>Sidéral</source>
         <translation>Holy</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="70"/>
+        <location filename="Data.cpp" line="71"/>
         <source>Fournaise</source>
         <translation>Flare</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="70"/>
+        <location filename="Data.cpp" line="71"/>
         <source>Météore</source>
         <translation>Meteor</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="70"/>
+        <location filename="Data.cpp" line="71"/>
         <source>Quake</source>
         <translation>Quake</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="70"/>
+        <location filename="Data.cpp" line="71"/>
         <source>Tornade</source>
         <translation>Tornado</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="70"/>
+        <location filename="Data.cpp" line="71"/>
         <source>Ultima</source>
         <translation>Ultima</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Apocalypse</source>
         <translation>Apocalypse</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Soin</source>
         <translation>Cure</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Soin Max</source>
         <translation>Curaga</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Vie</source>
         <translation>Life</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Vie Max</source>
         <translation>Full-life</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Récup</source>
         <translation>Regen</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Esuna</source>
         <translation>Esuna</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Anti-sort</source>
         <translation>Dispel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Carapace</source>
         <translation>Protect</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Blindage</source>
         <translation>Shell</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Aura</source>
         <translation>Aura</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Double</source>
         <translation>Double</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Triple</source>
         <translation>Triple</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Booster</source>
         <translation>Haste</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Somni</source>
         <translation>Slow</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Stop</source>
         <translation>Stop</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Cécité</source>
         <translation>Blind</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Folie</source>
         <translation>Confuse</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Morphée</source>
         <translation>Sleep</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Aphasie</source>
         <translation>Silence</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Mégalith</source>
         <translation>Break</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Ankou</source>
         <translation>Death</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Saignée</source>
         <translation>Drain</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Supplice</source>
         <translation>Pain</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Furie</source>
         <translation>Berserk</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Décubitus</source>
         <translation>Float</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Zombie</source>
         <translation>Zombie</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Meltdown</source>
         <translation>Meltdown</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Scan</source>
         <translation>Scan</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Joobu</source>
         <translation>Full-cure</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="75"/>
+        <location filename="Data.cpp" line="76"/>
         <source>Wall</source>
         <translation>Wall</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="75"/>
+        <location filename="Data.cpp" line="76"/>
         <source>Arkange</source>
         <translation>Rapture</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="75"/>
+        <location filename="Data.cpp" line="76"/>
         <source>The End</source>
         <translation>The End</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="75"/>
+        <location filename="Data.cpp" line="76"/>
         <source>Percent</source>
         <translation>Percent</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="75"/>
+        <location filename="Data.cpp" line="76"/>
         <source>Catastrophe</source>
         <translation>Catastrophe</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="80"/>
+        <location filename="Data.cpp" line="81"/>
         <source>Potion</source>
         <translation>Potion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="80"/>
+        <location filename="Data.cpp" line="81"/>
         <source>Potion+</source>
         <translation>Potion+</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="80"/>
+        <location filename="Data.cpp" line="81"/>
         <source>Hypra-Potion</source>
         <translation>Hi-Potion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="80"/>
+        <location filename="Data.cpp" line="81"/>
         <source>Maxi potion</source>
         <translation>Hi-Potion+</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="80"/>
+        <location filename="Data.cpp" line="81"/>
         <source>Potion totale</source>
         <translation>X-Potion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="81"/>
+        <location filename="Data.cpp" line="82"/>
         <source>Méga potion</source>
         <translation>Mega-Potion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="81"/>
+        <location filename="Data.cpp" line="82"/>
         <source>MT-Psy</source>
         <translation>Phoenix Down</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="81"/>
+        <location filename="Data.cpp" line="82"/>
         <source>Maxi MT-Psy</source>
         <translation>Mega Phoenix</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="81"/>
+        <location filename="Data.cpp" line="82"/>
         <source>Elixir</source>
         <translation>Elixir</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="81"/>
+        <location filename="Data.cpp" line="82"/>
         <source>Mégalixir</source>
         <translation>Megalixir</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="81"/>
+        <location filename="Data.cpp" line="82"/>
         <source>Antidote</source>
         <translation>Antidote</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="82"/>
+        <location filename="Data.cpp" line="83"/>
         <source>Défijeur</source>
         <translation>Soft</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="82"/>
+        <location filename="Data.cpp" line="83"/>
         <source>Lasik</source>
         <translation>Eye Drops</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="82"/>
+        <location filename="Data.cpp" line="83"/>
         <source>Bocca</source>
         <translation>Echo Screen</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="82"/>
+        <location filename="Data.cpp" line="83"/>
         <source>Eau bénite</source>
         <translation>Holy Water</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="82"/>
+        <location filename="Data.cpp" line="83"/>
         <source>Remède</source>
         <translation>Remedy</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="82"/>
+        <location filename="Data.cpp" line="83"/>
         <source>Remède +</source>
         <translation>Remedy+</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="83"/>
+        <location filename="Data.cpp" line="84"/>
         <source>1-20-Syble</source>
         <translation>Hero-trial</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="83"/>
+        <location filename="Data.cpp" line="84"/>
         <source>Invulnérable</source>
         <translation>Hero</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="83"/>
+        <location filename="Data.cpp" line="84"/>
         <source>1-destructible</source>
         <translation>Holy War-trial</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="83"/>
+        <location filename="Data.cpp" line="84"/>
         <source>Croisade</source>
         <translation>Holy War</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="83"/>
+        <location filename="Data.cpp" line="84"/>
         <source>Roc cosse</source>
         <translation>Shell Stone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="84"/>
+        <location filename="Data.cpp" line="85"/>
         <source>Roc carapace</source>
         <translation>Protect Stone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="84"/>
+        <location filename="Data.cpp" line="85"/>
         <source>Roc d&apos;Aura</source>
         <translation>Aura Stone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="84"/>
+        <location filename="Data.cpp" line="85"/>
         <source>Roc mortel</source>
         <translation>Death Stone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="84"/>
+        <location filename="Data.cpp" line="85"/>
         <source>Roc sacré</source>
         <translation>Holy Stone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="84"/>
+        <location filename="Data.cpp" line="85"/>
         <source>Roc flamboyant</source>
         <translation>Flare Stone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="85"/>
+        <location filename="Data.cpp" line="86"/>
         <source>Roc Météore</source>
         <translation>Meteor Stone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="85"/>
+        <location filename="Data.cpp" line="86"/>
         <source>Roc Ultima</source>
         <translation>Ultima Stone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="85"/>
+        <location filename="Data.cpp" line="86"/>
         <source>ChocoLégume</source>
         <translation>Gysahl Greens</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="85"/>
+        <location filename="Data.cpp" line="86"/>
         <source>Pen Pal</source>
         <translation>Friendship</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="86"/>
+        <location filename="Data.cpp" line="87"/>
         <source>Red Kross</source>
         <translation>Tent</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="86"/>
+        <location filename="Data.cpp" line="87"/>
         <source>Zoologie</source>
         <translation>Pet House</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="86"/>
+        <location filename="Data.cpp" line="87"/>
         <source>Saindoux</source>
         <translation>Cottage</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="86"/>
+        <location filename="Data.cpp" line="87"/>
         <source>Potion GF</source>
         <translation>G-Potion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="86"/>
+        <location filename="Data.cpp" line="87"/>
         <source>Potion GF +</source>
         <translation>G-Hi-Potion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="87"/>
+        <location filename="Data.cpp" line="88"/>
         <source>Mégapotion GF</source>
         <translation>G-Mega-Potion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="87"/>
+        <location filename="Data.cpp" line="88"/>
         <source>Sel marin</source>
         <translation>G-Returner</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="87"/>
+        <location filename="Data.cpp" line="88"/>
         <source>Carte baptême</source>
         <translation>Rename Card</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="87"/>
+        <location filename="Data.cpp" line="88"/>
         <source>Décapaciteur</source>
         <translation>Amnesia Greens</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="87"/>
+        <location filename="Data.cpp" line="88"/>
         <source>Livret HP-A</source>
         <translation>HP-J Scroll</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="88"/>
+        <location filename="Data.cpp" line="89"/>
         <source>Livret Vgr-A</source>
         <translation>Str-J Scroll</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="88"/>
+        <location filename="Data.cpp" line="89"/>
         <source>Livret Dfs-A</source>
         <translation>Vit-J Scroll</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="88"/>
+        <location filename="Data.cpp" line="89"/>
         <source>Livret Mgi-A</source>
         <translation>Mag-J Scroll</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="88"/>
+        <location filename="Data.cpp" line="89"/>
         <source>Livret Psy-A</source>
         <translation>Spr-J Scroll</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="88"/>
+        <location filename="Data.cpp" line="89"/>
         <source>Livret Vts-A</source>
         <translation>Spd-J Scroll</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="89"/>
+        <location filename="Data.cpp" line="90"/>
         <source>Livret Chc-A</source>
         <translation>Luck-J Scroll</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="89"/>
+        <location filename="Data.cpp" line="90"/>
         <source>Shadow</source>
         <translation>Aegis Amulet</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="89"/>
+        <location filename="Data.cpp" line="90"/>
         <source>Assaut Elé</source>
         <translation>Elem Atk</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="89"/>
+        <location filename="Data.cpp" line="90"/>
         <source>Antichoc Elé</source>
         <translation>Elem Guard</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="89"/>
+        <location filename="Data.cpp" line="90"/>
         <source>Assaut Mtl</source>
         <translation>Status Atk</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="90"/>
+        <location filename="Data.cpp" line="91"/>
         <source>Antichoc Mtl</source>
         <translation>Status Guard</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="90"/>
+        <location filename="Data.cpp" line="91"/>
         <source>Roc Rosette</source>
         <translation>Rosetta Stone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="90"/>
+        <location filename="Data.cpp" line="91"/>
         <source>GrimoMagic</source>
         <translation>Magic Scroll</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="90"/>
+        <location filename="Data.cpp" line="91"/>
         <source>GrimoForce</source>
         <translation>GF Scroll</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="90"/>
+        <location filename="Data.cpp" line="91"/>
         <source>GrimoVole</source>
         <translation>Draw Scroll</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="91"/>
+        <location filename="Data.cpp" line="92"/>
         <source>GrimObjets</source>
         <translation>Item Scroll</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="91"/>
+        <location filename="Data.cpp" line="92"/>
         <source>Vegas Feel</source>
         <translation>Gambler Spirit</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="91"/>
+        <location filename="Data.cpp" line="92"/>
         <source>Sanatorium</source>
         <translation>Healing Ring</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="91"/>
+        <location filename="Data.cpp" line="92"/>
         <source>MétemPsy</source>
         <translation>Phoenix Spirit</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="91"/>
+        <location filename="Data.cpp" line="92"/>
         <source>Bandage</source>
         <translation>Med Kit</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="91"/>
+        <location filename="Data.cpp" line="92"/>
         <source>Nova</source>
         <translation>Bomb Spirit</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="92"/>
+        <location filename="Data.cpp" line="93"/>
         <source>Régime</source>
         <translation>Hungry Cookpot</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="92"/>
+        <location filename="Data.cpp" line="93"/>
         <source>Kikkou Mania</source>
         <translation>Mog&apos;s Amulet</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="92"/>
+        <location filename="Data.cpp" line="93"/>
         <source>Samâdhi</source>
         <translation>Steel Pipe</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="92"/>
+        <location filename="Data.cpp" line="93"/>
         <source>Zodiaque</source>
         <translation>Star Fragment</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="92"/>
+        <location filename="Data.cpp" line="93"/>
         <source>Nuclide</source>
         <translation>Energy Crystal</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="92"/>
+        <location filename="Data.cpp" line="93"/>
         <source>Sacrum</source>
         <translation>Samantha Soul</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="93"/>
+        <location filename="Data.cpp" line="94"/>
         <source>Billet</source>
         <translation>Healing Mail</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="93"/>
+        <location filename="Data.cpp" line="94"/>
         <source>Armure d&apos;or</source>
         <translation>Gold Armor</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="93"/>
+        <location filename="Data.cpp" line="94"/>
         <source>Cuirasse</source>
         <translation>Diamond Armor</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="93"/>
+        <location filename="Data.cpp" line="94"/>
         <source>Anneau Récup</source>
         <translation>Regen Ring</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="93"/>
+        <location filename="Data.cpp" line="94"/>
         <source>Alliance</source>
         <translation>Giant&apos;s Ring</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="93"/>
+        <location filename="Data.cpp" line="94"/>
         <source>Vierge</source>
         <comment>item1</comment>
         <translation>Silver Mail</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="94"/>
+        <location filename="Data.cpp" line="95"/>
         <source>Bague Gaêa</source>
         <translation>Gaea&apos;s Ring</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="94"/>
+        <location filename="Data.cpp" line="95"/>
         <source>Vitamine</source>
         <translation>Strength Love</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="94"/>
+        <location filename="Data.cpp" line="95"/>
         <source>Sagou</source>
         <translation>Power Wrist</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="94"/>
+        <location filename="Data.cpp" line="95"/>
         <source>Sagette</source>
         <translation>Hyper Wrist</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="94"/>
+        <location filename="Data.cpp" line="95"/>
         <source>Coquille</source>
         <translation>Turtle Shell</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="94"/>
+        <location filename="Data.cpp" line="95"/>
         <source>Halcyon</source>
         <translation>Orihalcon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="95"/>
+        <location filename="Data.cpp" line="96"/>
         <source>Adamantine</source>
         <translation>Adamantine</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="95"/>
+        <location filename="Data.cpp" line="96"/>
         <source>Obole</source>
         <translation>Rune Armlet</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="95"/>
+        <location filename="Data.cpp" line="96"/>
         <source>Tao</source>
         <translation>Force Armlet</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="95"/>
+        <location filename="Data.cpp" line="96"/>
         <source>Lacan</source>
         <translation>Magic Armlet</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="95"/>
+        <location filename="Data.cpp" line="96"/>
         <source>Garcinord</source>
         <translation>Circlet</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="95"/>
+        <location filename="Data.cpp" line="96"/>
         <source>Merlin</source>
         <translation>Hypno Crown</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="96"/>
+        <location filename="Data.cpp" line="97"/>
         <source>Magax</source>
         <translation>Royal Crown</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="96"/>
+        <location filename="Data.cpp" line="97"/>
         <source>Injection</source>
         <translation>Jet Engine</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="96"/>
+        <location filename="Data.cpp" line="97"/>
         <source>SuperSonic</source>
         <translation>Rocket Engine</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="96"/>
+        <location filename="Data.cpp" line="97"/>
         <source>Pied de biche</source>
         <translation>Moon Curtain</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="96"/>
+        <location filename="Data.cpp" line="97"/>
         <source>Ecaille</source>
         <translation>Steel Curtain</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="96"/>
+        <location filename="Data.cpp" line="97"/>
         <source>Tasmania</source>
         <translation>Glow Curtain</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="97"/>
+        <location filename="Data.cpp" line="98"/>
         <source>Speedy</source>
         <translation>Accelerator</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="97"/>
+        <location filename="Data.cpp" line="98"/>
         <source>Réactor</source>
         <translation>Monk&apos;s Code</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="97"/>
+        <location filename="Data.cpp" line="98"/>
         <source>Protector</source>
         <translation>Knight&apos;s Code</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="97"/>
+        <location filename="Data.cpp" line="98"/>
         <source>Pasteur</source>
         <translation>Doc&apos;s Code</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="97"/>
+        <location filename="Data.cpp" line="98"/>
         <source>Manivelle</source>
         <translation>Hundred Needles</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="97"/>
+        <location filename="Data.cpp" line="98"/>
         <source>Trilogie</source>
         <translation>Three Stars</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="98"/>
+        <location filename="Data.cpp" line="99"/>
         <source>Balles normales</source>
         <translation>Normal Ammo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="98"/>
+        <location filename="Data.cpp" line="99"/>
         <source>Mitra-balles</source>
         <translation>Shotgun Ammo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="98"/>
+        <location filename="Data.cpp" line="99"/>
         <source>Dark balles</source>
         <translation>Dark Ammo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="98"/>
+        <location filename="Data.cpp" line="99"/>
         <source>Balles foudre</source>
         <translation>Fire Ammo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="98"/>
+        <location filename="Data.cpp" line="99"/>
         <source>Freud</source>
         <comment>item</comment>
         <translation>Ribbon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="99"/>
+        <location filename="Data.cpp" line="100"/>
         <source>Balles tornade</source>
         <translation>Demolition Ammo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="99"/>
+        <location filename="Data.cpp" line="100"/>
         <source>Balles véloces</source>
         <translation>Fast Ammo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="99"/>
+        <location filename="Data.cpp" line="100"/>
         <source>Balles anti-char</source>
         <translation>AP Ammo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="99"/>
+        <location filename="Data.cpp" line="100"/>
         <source>Balles Pulsar</source>
         <translation>Pulse Ammo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="99"/>
+        <location filename="Data.cpp" line="100"/>
         <source>Caillou magik</source>
         <translation>M-Stone Piece</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="100"/>
+        <location filename="Data.cpp" line="101"/>
         <source>Roc initiatique</source>
         <translation>Magic Stone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="100"/>
+        <location filename="Data.cpp" line="101"/>
         <source>Roc féerique</source>
         <translation>Wizard Stone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="100"/>
+        <location filename="Data.cpp" line="101"/>
         <source>Tentacule</source>
         <translation>Ochu Tentacle</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="100"/>
+        <location filename="Data.cpp" line="101"/>
         <source>Onde bénite</source>
         <translation>Healing Water</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="100"/>
+        <location filename="Data.cpp" line="101"/>
         <source>Plumage</source>
         <translation>Cockatrice Pinion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="101"/>
+        <location filename="Data.cpp" line="102"/>
         <source>Poudre Zombie</source>
         <translation>Zombie Powder</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="101"/>
+        <location filename="Data.cpp" line="102"/>
         <source>Bottes de 7km</source>
         <translation>Lightweight</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="101"/>
+        <location filename="Data.cpp" line="102"/>
         <source>9 inch nail</source>
         <translation>Sharp Spike</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="101"/>
+        <location filename="Data.cpp" line="102"/>
         <source>Enclume</source>
         <translation>Screw</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="101"/>
+        <location filename="Data.cpp" line="102"/>
         <source>Cimeterre</source>
         <translation>Saw Blade</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="102"/>
+        <location filename="Data.cpp" line="103"/>
         <source>Corne</source>
         <translation>Mesmerize Blade</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="102"/>
+        <location filename="Data.cpp" line="103"/>
         <source>Sanguine</source>
         <translation>Vampire Fang</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="102"/>
+        <location filename="Data.cpp" line="103"/>
         <source>EuFurysant</source>
         <translation>Fury Fragment</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="102"/>
+        <location filename="Data.cpp" line="103"/>
         <source>Epée trompeuse</source>
         <translation>Betrayal Sword</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="102"/>
+        <location filename="Data.cpp" line="103"/>
         <source>Poudre Morphée</source>
         <translation>Sleep Powder</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="103"/>
+        <location filename="Data.cpp" line="104"/>
         <source>Anneau de vie</source>
         <translation>Life Ring</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="103"/>
+        <location filename="Data.cpp" line="104"/>
         <source>Lochness</source>
         <translation>Dragon Fang</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="103"/>
+        <location filename="Data.cpp" line="104"/>
         <source>U-Boat</source>
         <translation>Spider Web</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="103"/>
+        <location filename="Data.cpp" line="104"/>
         <source>Etoile</source>
         <translation>Coral Fragment</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="103"/>
+        <location filename="Data.cpp" line="104"/>
         <source>Weirdo</source>
         <translation>Curse Spike</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="103"/>
+        <location filename="Data.cpp" line="104"/>
         <source>Gen-X</source>
         <translation>Black Hole</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="104"/>
+        <location filename="Data.cpp" line="105"/>
         <source>Fluide</source>
         <translation>Water Crystal</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="104"/>
+        <location filename="Data.cpp" line="105"/>
         <source>M-Double</source>
         <translation>Missile</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="104"/>
+        <location filename="Data.cpp" line="105"/>
         <source>House</source>
         <translation>Mystery Fluid</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="104"/>
+        <location filename="Data.cpp" line="105"/>
         <source>Chevrotine</source>
         <translation>Running Fire</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="104"/>
+        <location filename="Data.cpp" line="105"/>
         <source>Canicule</source>
         <translation>Inferno Fang</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="104"/>
+        <location filename="Data.cpp" line="105"/>
         <source>Germe</source>
         <translation>Malboro Tentacle</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="105"/>
+        <location filename="Data.cpp" line="106"/>
         <source>Rhône</source>
         <translation>Whisper</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="105"/>
+        <location filename="Data.cpp" line="106"/>
         <source>Rayon</source>
         <translation>Laser Cannon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="105"/>
+        <location filename="Data.cpp" line="106"/>
         <source>V-Choc</source>
         <translation>Power Generator</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="105"/>
+        <location filename="Data.cpp" line="106"/>
         <source>H-Espace</source>
         <translation>Dark Matter</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="105"/>
+        <location filename="Data.cpp" line="106"/>
         <source>Hot Rock</source>
         <translation>Bomb Fragment</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="105"/>
+        <location filename="Data.cpp" line="106"/>
         <source>Vierge</source>
         <comment>item2</comment>
         <translation>Barrier</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="106"/>
+        <location filename="Data.cpp" line="107"/>
         <source>Molaire</source>
         <translation>Red Fang</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="106"/>
+        <location filename="Data.cpp" line="107"/>
         <source>Blizzard</source>
         <translation>Arctic Wind</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="106"/>
+        <location filename="Data.cpp" line="107"/>
         <source>Nunatak</source>
         <translation>North Wind</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="106"/>
+        <location filename="Data.cpp" line="107"/>
         <source>Gemma Luce</source>
         <translation>Dynamo Stone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="106"/>
+        <location filename="Data.cpp" line="107"/>
         <source>Aigrette</source>
         <translation>Shear Feather</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="106"/>
+        <location filename="Data.cpp" line="107"/>
         <source>Canine</source>
         <translation>Venom Fang</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="107"/>
+        <location filename="Data.cpp" line="108"/>
         <source>Globe d&apos;acier</source>
         <translation>Steel Orb</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="107"/>
+        <location filename="Data.cpp" line="108"/>
         <source>Roc lunaire</source>
         <translation>Moon Stone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="107"/>
+        <location filename="Data.cpp" line="108"/>
         <source>Fémur</source>
         <translation>Dino Bone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="107"/>
+        <location filename="Data.cpp" line="108"/>
         <source>Aquilon</source>
         <translation>Windmill</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="107"/>
+        <location filename="Data.cpp" line="108"/>
         <source>Derme</source>
         <translation>Dragon Skin</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="107"/>
+        <location filename="Data.cpp" line="108"/>
         <source>Zygène</source>
         <translation>Fish Fin</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="108"/>
+        <location filename="Data.cpp" line="109"/>
         <source>Shark</source>
         <translation>Dragon Fin</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="108"/>
+        <location filename="Data.cpp" line="109"/>
         <source>Poudre Aphasie</source>
         <translation>Silence Powder</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="108"/>
+        <location filename="Data.cpp" line="109"/>
         <source>Venin</source>
         <translation>Poison Powder</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="108"/>
+        <location filename="Data.cpp" line="109"/>
         <source>Revenant</source>
         <translation>Dead Spirit</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="108"/>
+        <location filename="Data.cpp" line="109"/>
         <source>Désosseur </source>
         <translation>Chef&apos;s Knife</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="108"/>
+        <location filename="Data.cpp" line="109"/>
         <source>Kaktos</source>
         <translation>Cactus Thorn</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="109"/>
+        <location filename="Data.cpp" line="110"/>
         <source>Roc Shaman</source>
         <translation>Shaman Stone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="109"/>
+        <location filename="Data.cpp" line="110"/>
         <source>Essence</source>
         <translation>Fuel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="109"/>
+        <location filename="Data.cpp" line="110"/>
         <source>Comtesse Cochon</source>
         <translation>Girl Next Door</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="109"/>
+        <location filename="Data.cpp" line="110"/>
         <source>Missive d&apos;Edea</source>
         <translation>Sorceress&apos; Letter</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="109"/>
+        <location filename="Data.cpp" line="110"/>
         <source>Collier Chocobo</source>
         <translation>Chocobo&apos;s Tag</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="110"/>
+        <location filename="Data.cpp" line="111"/>
         <source>Collier chien</source>
         <translation>Pet Nametag</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="110"/>
+        <location filename="Data.cpp" line="111"/>
         <source>Bague du chef</source>
         <translation>Solomon Ring</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="110"/>
+        <location filename="Data.cpp" line="111"/>
         <source>Aladore</source>
         <translation>Magical Lamp</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="53"/>
+        <location filename="Data.cpp" line="54"/>
         <source>Bonus HP</source>
         <comment>ability</comment>
         <translation>HP Bonus</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="54"/>
+        <location filename="Data.cpp" line="55"/>
         <source>Bonus Vgr</source>
         <comment>ability</comment>
         <translation>Str Bonus</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="54"/>
+        <location filename="Data.cpp" line="55"/>
         <source>Bonus Dfs</source>
         <comment>ability</comment>
         <translation>Vit Bonus</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="54"/>
+        <location filename="Data.cpp" line="55"/>
         <source>Bonus Mgi</source>
         <comment>ability</comment>
         <translation>Mag Bonus</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="54"/>
+        <location filename="Data.cpp" line="55"/>
         <source>Bonus Psy</source>
         <comment>ability</comment>
         <translation>Spr Bonus</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="110"/>
+        <location filename="Data.cpp" line="111"/>
         <source>Bonus Hp</source>
         <comment>item</comment>
         <translation>HP Up</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="110"/>
+        <location filename="Data.cpp" line="111"/>
         <source>Bonus Vgr</source>
         <comment>item</comment>
         <translation>Str Up</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="111"/>
+        <location filename="Data.cpp" line="112"/>
         <source>Bonus Dfs</source>
         <comment>item</comment>
         <translation>Vit Up</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="111"/>
+        <location filename="Data.cpp" line="112"/>
         <source>Bonus Mgi</source>
         <comment>item</comment>
         <translation>Mag Up</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="111"/>
+        <location filename="Data.cpp" line="112"/>
         <source>Bonus Psy</source>
         <comment>item</comment>
         <translation>Spr Up</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="111"/>
+        <location filename="Data.cpp" line="112"/>
         <source>Bonus Vts</source>
         <comment>item</comment>
         <translation>Spd Up</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="111"/>
+        <location filename="Data.cpp" line="112"/>
         <source>Bonus Chc</source>
         <comment>item</comment>
         <translation>Luck Up</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="112"/>
+        <location filename="Data.cpp" line="113"/>
         <source>Amour bestial</source>
         <translation>LuvLuv G</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="112"/>
+        <location filename="Data.cpp" line="113"/>
         <source>F.F.F. Fév</source>
         <translation>Weapons Mon 1st</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="112"/>
+        <location filename="Data.cpp" line="113"/>
         <source>F.F.F. Mar</source>
         <translation>Weapons Mon Mar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="112"/>
+        <location filename="Data.cpp" line="113"/>
         <source>F.F.F. Avr</source>
         <translation>Weapons Mon Apr</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="112"/>
+        <location filename="Data.cpp" line="113"/>
         <source>F.F.F. Mai</source>
         <translation>Weapons Mon May</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="113"/>
+        <location filename="Data.cpp" line="114"/>
         <source>F.F.F. Jun</source>
         <translation>Weapons Mon Jun</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="113"/>
+        <location filename="Data.cpp" line="114"/>
         <source>F.F.F. Jul</source>
         <translation>Weapons Mon Jul</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="113"/>
+        <location filename="Data.cpp" line="114"/>
         <source>F.F.F. Aoû</source>
         <translation>Weapons Mon Aug</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="113"/>
+        <location filename="Data.cpp" line="114"/>
         <source>Baston mag 1</source>
         <translation>Combat King 001</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="113"/>
+        <location filename="Data.cpp" line="114"/>
         <source>Baston mag 2</source>
         <translation>Combat King 002</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="114"/>
+        <location filename="Data.cpp" line="115"/>
         <source>Baston mag 3</source>
         <translation>Combat King 003</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="114"/>
+        <location filename="Data.cpp" line="115"/>
         <source>Baston mag 4</source>
         <translation>Combat King 004</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="114"/>
+        <location filename="Data.cpp" line="115"/>
         <source>Baston mag 5</source>
         <translation>Combat King 005</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="114"/>
+        <location filename="Data.cpp" line="115"/>
         <source>L&apos;A D bêtes 1</source>
         <translation>Pet Pals Vol.1</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="114"/>
+        <location filename="Data.cpp" line="115"/>
         <source>L&apos;A D bêtes 2</source>
         <translation>Pet Pals Vol.2</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="115"/>
+        <location filename="Data.cpp" line="116"/>
         <source>L&apos;A D bêtes 3</source>
         <translation>Pet Pals Vol.3</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="115"/>
+        <location filename="Data.cpp" line="116"/>
         <source>L&apos;A D bêtes 4</source>
         <translation>Pet Pals Vol.4</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="115"/>
+        <location filename="Data.cpp" line="116"/>
         <source>L&apos;A D bêtes 5</source>
         <translation>Pet Pals Vol.5</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="115"/>
+        <location filename="Data.cpp" line="116"/>
         <source>L&apos;A D bêtes 6</source>
         <translation>Pet Pals Vol.6</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="115"/>
+        <location filename="Data.cpp" line="116"/>
         <source>Occult Fan I</source>
         <translation>Occult Fan I</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="116"/>
+        <location filename="Data.cpp" line="117"/>
         <source>Occult Fan II</source>
         <translation>Occult Fan II</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="116"/>
+        <location filename="Data.cpp" line="117"/>
         <source>Occult Fan III</source>
         <translation>Occult Fan III</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="116"/>
+        <location filename="Data.cpp" line="117"/>
         <source>Occult Fan IV</source>
         <translation>Occult Fan IV</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="141"/>
+        <location filename="Data.cpp" line="154"/>
         <source>Pistolame</source>
         <translation>Revolver</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="141"/>
+        <location filename="Data.cpp" line="154"/>
         <source>Nacre Blade</source>
         <translation>Shear Trigger</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="141"/>
+        <location filename="Data.cpp" line="154"/>
         <source>Dragon Blade</source>
         <translation>Cutting Trigger</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="141"/>
+        <location filename="Data.cpp" line="154"/>
         <source>Sabreur</source>
         <translation>Flame Saber</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="141"/>
+        <location filename="Data.cpp" line="154"/>
         <source>Katana</source>
         <translation>Twin Lance</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="141"/>
+        <location filename="Data.cpp" line="154"/>
         <source>Kendo</source>
         <translation>Punishment</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="141"/>
+        <location filename="Data.cpp" line="154"/>
         <source>Lionheart</source>
         <translation>Lion Heart</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="142"/>
+        <location filename="Data.cpp" line="155"/>
         <source>Metal Gloves</source>
         <translation>Metal Knuckle</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="142"/>
+        <location filename="Data.cpp" line="155"/>
         <source>Maverick</source>
         <translation>Maverick</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="142"/>
+        <location filename="Data.cpp" line="155"/>
         <source>Gauntlets</source>
         <translation>Gauntlet</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="142"/>
+        <location filename="Data.cpp" line="155"/>
         <source>Ehrgeiz</source>
         <translation>Ehrgeiz</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="143"/>
+        <location filename="Data.cpp" line="156"/>
         <source>W.W.West</source>
         <translation>Valiant</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="143"/>
+        <location filename="Data.cpp" line="156"/>
         <source>Roosevelt</source>
         <translation>Ulysses</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="143"/>
+        <location filename="Data.cpp" line="156"/>
         <source>Bertha</source>
         <translation>Bismarck</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="143"/>
+        <location filename="Data.cpp" line="156"/>
         <source>Steel Gun</source>
         <translation>Exeter</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="144"/>
+        <location filename="Data.cpp" line="157"/>
         <source>Gibet</source>
         <translation>Chain Whip</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="144"/>
+        <location filename="Data.cpp" line="157"/>
         <source>Totally S.M.</source>
         <translation>Slaying Tail</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="144"/>
+        <location filename="Data.cpp" line="157"/>
         <source>Red Scorpio</source>
         <translation>Red Scorpion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="144"/>
+        <location filename="Data.cpp" line="157"/>
         <source>Smiley</source>
         <translation>Save the Queen</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="145"/>
+        <location filename="Data.cpp" line="158"/>
         <source>Rotator</source>
         <translation>Pinwheel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="145"/>
+        <location filename="Data.cpp" line="158"/>
         <source>Walkyrie</source>
         <translation>Valkyrie</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="145"/>
+        <location filename="Data.cpp" line="158"/>
         <source>Ninja Sun</source>
         <translation>Rising Sun</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="145"/>
+        <location filename="Data.cpp" line="158"/>
         <source>Ptérodactyle</source>
         <translation>Cardinal</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="145"/>
+        <location filename="Data.cpp" line="158"/>
         <source>Tronçonneur</source>
         <translation>Shooting Star</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="146"/>
+        <location filename="Data.cpp" line="159"/>
         <source>Nunchak Red</source>
         <translation>Flail</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="146"/>
+        <location filename="Data.cpp" line="159"/>
         <source>Nunchak Blue</source>
         <translation>Morning Star</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="146"/>
+        <location filename="Data.cpp" line="159"/>
         <source>Islam Star</source>
         <translation>Crescent Wish</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="147"/>
+        <location filename="Data.cpp" line="160"/>
         <source>Hyperion</source>
         <translation>Hyperion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="147"/>
+        <location filename="Data.cpp" line="160"/>
         <source>Nada</source>
         <translation>None</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="147"/>
+        <location filename="Data.cpp" line="160"/>
         <source>Kalachnikov</source>
         <translation>Machine Gun</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="147"/>
+        <location filename="Data.cpp" line="160"/>
         <source>Katal</source>
         <translation>Katal</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="147"/>
+        <location filename="Data.cpp" line="160"/>
         <source>Harpoon</source>
         <translation>Harpoon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="152"/>
-        <location filename="Data.cpp" line="211"/>
-        <location filename="Data.cpp" line="812"/>
+        <location filename="Data.cpp" line="165"/>
+        <location filename="Data.cpp" line="224"/>
+        <location filename="Data.cpp" line="826"/>
         <source>Squall</source>
         <translation>Squall</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="152"/>
-        <location filename="Data.cpp" line="210"/>
+        <location filename="Data.cpp" line="165"/>
+        <location filename="Data.cpp" line="223"/>
         <source>Zell</source>
         <translation>Zell</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="152"/>
-        <location filename="Data.cpp" line="210"/>
+        <location filename="Data.cpp" line="165"/>
+        <location filename="Data.cpp" line="223"/>
         <source>Irvine</source>
         <translation>Irvine</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="152"/>
-        <location filename="Data.cpp" line="210"/>
+        <location filename="Data.cpp" line="165"/>
+        <location filename="Data.cpp" line="223"/>
         <source>Quistis</source>
         <translation>Quistis</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="152"/>
-        <location filename="Data.cpp" line="211"/>
+        <location filename="Data.cpp" line="165"/>
+        <location filename="Data.cpp" line="224"/>
         <source>Linoa</source>
         <translation>Rinoa</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="153"/>
-        <location filename="Data.cpp" line="210"/>
+        <location filename="Data.cpp" line="166"/>
+        <location filename="Data.cpp" line="223"/>
         <source>Selphie</source>
         <translation>Selphie</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="153"/>
-        <location filename="Data.cpp" line="211"/>
+        <location filename="Data.cpp" line="166"/>
+        <location filename="Data.cpp" line="224"/>
         <source>Seifer</source>
         <translation>Seifer</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="153"/>
-        <location filename="Data.cpp" line="211"/>
+        <location filename="Data.cpp" line="166"/>
+        <location filename="Data.cpp" line="224"/>
         <source>Edea</source>
         <translation>Edea</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="153"/>
-        <location filename="Data.cpp" line="210"/>
+        <location filename="Data.cpp" line="166"/>
+        <location filename="Data.cpp" line="223"/>
         <source>Laguna</source>
         <translation>Laguna</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="153"/>
-        <location filename="Data.cpp" line="210"/>
+        <location filename="Data.cpp" line="166"/>
+        <location filename="Data.cpp" line="223"/>
         <source>Kiros</source>
         <translation>Kiros</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="154"/>
-        <location filename="Data.cpp" line="209"/>
+        <location filename="Data.cpp" line="167"/>
+        <location filename="Data.cpp" line="222"/>
         <source>Ward</source>
         <translation>Ward</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="154"/>
+        <location filename="Data.cpp" line="167"/>
         <source>Cronos</source>
         <translation>Griever</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="154"/>
+        <location filename="Data.cpp" line="167"/>
         <source>MiniMog</source>
         <translation>MiniMog</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="154"/>
+        <location filename="Data.cpp" line="167"/>
         <source>Angel</source>
         <translation>Angelo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="207"/>
+        <location filename="Data.cpp" line="220"/>
         <source>Shiva</source>
         <comment>card</comment>
         <translation>Shiva</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="207"/>
+        <location filename="Data.cpp" line="220"/>
         <source>Ifrit</source>
         <comment>card</comment>
         <translation>Ifrit</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="207"/>
+        <location filename="Data.cpp" line="220"/>
         <source>Ondine</source>
         <comment>card</comment>
         <translation>Siren</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="207"/>
+        <location filename="Data.cpp" line="220"/>
         <source>Tauros</source>
         <comment>card</comment>
         <translation>Sacred</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="207"/>
+        <location filename="Data.cpp" line="220"/>
         <source>Taurux</source>
         <comment>card</comment>
         <translation>Minotaur</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="208"/>
+        <location filename="Data.cpp" line="221"/>
         <source>Ahuri</source>
         <comment>card</comment>
         <translation>Carbuncle</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="208"/>
+        <location filename="Data.cpp" line="221"/>
         <source>Nosferatu</source>
         <comment>card</comment>
         <translation>Diablos</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="208"/>
+        <location filename="Data.cpp" line="221"/>
         <source>Leviathan</source>
         <comment>card</comment>
         <translation>Leviathan</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="208"/>
+        <location filename="Data.cpp" line="221"/>
         <source>Odin</source>
         <comment>card</comment>
         <translation>Odin</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="208"/>
+        <location filename="Data.cpp" line="221"/>
         <source>Zéphyr</source>
         <comment>card</comment>
         <translation>Pandemona</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="209"/>
+        <location filename="Data.cpp" line="222"/>
         <source>Alexander</source>
         <comment>card</comment>
         <translation>Alexander</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="209"/>
+        <location filename="Data.cpp" line="222"/>
         <source>Phénix</source>
         <comment>card</comment>
         <translation>Phoenix</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="209"/>
+        <location filename="Data.cpp" line="222"/>
         <source>Bahamut</source>
         <comment>card</comment>
         <translation>Bahamut</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="209"/>
+        <location filename="Data.cpp" line="222"/>
         <source>Helltrain</source>
         <comment>card</comment>
         <translation>Doomtrain</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="209"/>
+        <location filename="Data.cpp" line="222"/>
         <source>Orbital</source>
         <comment>card</comment>
         <translation>Eden</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="159"/>
+        <location filename="Data.cpp" line="172"/>
         <source>Golgotha</source>
         <comment>gf</comment>
         <translation>Quezacotl</translation>
@@ -4710,2543 +4715,2658 @@ By default Hyne attempts to automatically sign saves, but in case of error, you 
         <translation type="obsolete">Death Claw</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="167"/>
+        <location filename="Data.cpp" line="180"/>
         <source>Top Punch</source>
         <translation>Punch Rush</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="69"/>
+        <location filename="Data.cpp" line="70"/>
         <source>H2o</source>
         <translation>Water</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Soin +</source>
         <translation>Cura</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Boomrg</source>
         <translation>Reflect</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Plaines d&apos;Arkland - Balamb</source>
         <comment>1</comment>
         <translation>Balamb- Alcauld Plains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Monts Gaulg - Balamb</source>
         <comment>2</comment>
         <translation>Balamb- Gaulg Mountains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Baie de Rinaul - Balamb</source>
         <comment>3</comment>
         <translation>Balamb- Rinaul Coast</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Cap Raha - Balamb</source>
         <comment>4</comment>
         <translation>Balamb- Raha Cape</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Forêt de Rosfall - Timber</source>
         <comment>5</comment>
         <translation>Timber- Roshfall Forest</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Mandy Beach - Timber</source>
         <comment>6</comment>
         <translation>Timber- Mandy Beach</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Lac Obel - Timber</source>
         <comment>7</comment>
         <translation>Timber- Obel Lake</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Vallée de Lanker - Timber</source>
         <comment>8</comment>
         <translation>Timber- Lanker Plains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Ile Nantakhet - Timber</source>
         <comment>9</comment>
         <translation>Timber- Nanchucket Island</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Yaulny Canyon - Timber</source>
         <comment>10</comment>
         <translation>Timber- Yaulny Canyon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Val Hasberry - Dollet</source>
         <comment>11</comment>
         <translation>Dollet- Hasberry Plains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Cap Holy Glory - Dollet</source>
         <comment>12</comment>
         <translation>Dollet- Holy Glory Cape</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Longhorn Island - Dollet</source>
         <comment>13</comment>
         <translation>Dollet- Long Horn Island</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Péninsule Malgo - Dollet</source>
         <comment>14</comment>
         <translation>Dollet- Malgo Peninsula</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Plateau Monterosa - Galbadia</source>
         <comment>15</comment>
         <translation>Galbadia- Monterosa Plateau</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Lallapalooza Canyon - Galbadia</source>
         <comment>16</comment>
         <translation>Galbadia- Lallapalooza Canyon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Shenand Hill - Timber</source>
         <comment>17</comment>
         <translation>Timber- Shenand Hill</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Péninsule Gotland - Galbadia</source>
         <comment>18</comment>
         <translation>Galbadia- Gotland Peninsula</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Ile de l&apos;Enfer - Galbadia</source>
         <comment>19</comment>
         <translation>Island Closest to Hell</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Plaine Galbadienne</source>
         <comment>20</comment>
         <translation>Great Plains of Galbadia</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Wilburn Hill - Galbadia</source>
         <comment>21</comment>
         <translation>Galbadia- Wilburn Hill</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Archipel Rem - Galbadia</source>
         <comment>22</comment>
         <translation>Galbadia- Rem Archipelago</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Dingo Désert - Galbadia</source>
         <comment>23</comment>
         <translation>Galbadia- Dingo Desert</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Cap Winhill</source>
         <comment>24</comment>
         <translation>Winhill- Winhill Bluffs</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Archipel Humphrey - Winhill</source>
         <comment>25</comment>
         <translation>Winhill- Humphrey Archipelago</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Ile Winter - Trabia</source>
         <comment>26</comment>
         <translation>Trabia- Winter Island</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Val de Solvard - Trabia</source>
         <comment>27</comment>
         <translation>Trabia- Sorbald Snowfield</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Crête d&apos;Eldbeak - Trabia</source>
         <comment>28</comment>
         <translation>Trabia- Eldbeak Peninsula</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Plaine d&apos;Hawkind - Trabia</source>
         <comment>30</comment>
         <translation>Trabia- Hawkwind Plains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Atoll Albatross - Trabia</source>
         <comment>31</comment>
         <translation>Trabia- Albatross Archipelago</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Vallon de Bika - Trabia</source>
         <comment>32</comment>
         <translation>Trabia- Bika Snowfield</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Péninsule Thor - Trabia</source>
         <comment>33</comment>
         <translation>Trabia- Thor Peninsula</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Crête d&apos;Heath - Trabia</source>
         <comment>35</comment>
         <translation>Trabia- Heath Peninsula</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Trabia Crater - Trabia</source>
         <comment>36</comment>
         <translation>Trabia- Trabia Crater</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Mont Vienne - Trabia</source>
         <comment>37</comment>
         <translation>Trabia- Vienne Mountains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Plaine de Mordor - Esthar</source>
         <comment>38</comment>
         <translation>Esthar- Mordred Plains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Mont Nortes - Esthar</source>
         <comment>39</comment>
         <translation>Esthar- Nortes Mountains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Atoll Fulcura - Esthar</source>
         <comment>40</comment>
         <translation>Esthar- Fulcura Archipelago</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Forêt Grandidi - Esthar</source>
         <comment>41</comment>
         <translation>Esthar- Grandidi Forest</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Iles Millefeuilles - Esthar</source>
         <comment>42</comment>
         <translation>Esthar- Millefeuille Archipelago</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Grandes plaines d&apos;Esthar</source>
         <comment>43</comment>
         <translation>Great Plains of Esthar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Esthar City</source>
         <comment>44</comment>
         <translation>Esthar City</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Salt Lake - Esthar</source>
         <comment>45</comment>
         <translation>Esthar- Great Salt Lake</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Côte Ouest - Esthar</source>
         <comment>46</comment>
         <translation>Esthar- West Coast</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Mont Sollet - Esthar</source>
         <comment>47</comment>
         <translation>Esthar- Sollet Mountains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Vallée d&apos;Abadan - Esthar</source>
         <comment>48</comment>
         <translation>Esthar- Abadan Plains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Ile Minde - Esthar</source>
         <comment>49</comment>
         <translation>Esthar- Minde Island</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Désert Kashkabald - Esthar</source>
         <comment>50</comment>
         <translation>Esthar- Kashkabald Desert</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Ile Paradisiaque - Esthar</source>
         <comment>51</comment>
         <translation>Island Closest to Heaven</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Pic de Talle - Esthar</source>
         <comment>52</comment>
         <translation>Esthar- Talle Mountains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Atoll Shalmal - Esthar</source>
         <comment>53</comment>
         <translation>Esthar- Shalmal Peninsula</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Vallée de Lolestern - Centra</source>
         <comment>54</comment>
         <translation>Centra- Lolestern Plains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Aiguille d&apos;Almage - Centra</source>
         <comment>55</comment>
         <translation>Centra- Almaj Mountains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Vallon Lenown - Centra</source>
         <comment>56</comment>
         <translation>Centra- Lenown Plains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Cap de l&apos;espoir - Centra</source>
         <comment>57</comment>
         <translation>Centra- Cape of Good Hope</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Mont Yorn - Centra</source>
         <comment>58</comment>
         <translation>Centra- Yorn Mountains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Ile Pampa - Esthar</source>
         <comment>59</comment>
         <translation>Esthar- Cactuar Island</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Val Serengetti - Centra</source>
         <comment>60</comment>
         <translation>Centra- Serengetti Plains</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Péninsule Nectalle - Centra</source>
         <comment>61</comment>
         <translation>Centra- Nectar Peninsula</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Centra Crater - Centra</source>
         <comment>62</comment>
         <translation>Centra- Centra Crater</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Ile Poccarahi - Centra</source>
         <comment>63</comment>
         <translation>Centra- Poccarahi Island</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Bibliothèque - BGU</source>
         <comment>64</comment>
         <translation>B-Garden- Library</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Entrée - BGU</source>
         <comment>65</comment>
         <translation>B-Garden- Front Gate</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Salle de cours - BGU</source>
         <comment>66</comment>
         <translation>B-Garden- Classroom</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Cafétéria - BGU</source>
         <comment>67</comment>
         <translation>B-Garden- Cafeteria</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Niveau MD - BGU</source>
         <comment>68</comment>
         <translation>B-Garden- MD Level</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Hall 1er étage - BGU</source>
         <comment>69</comment>
         <translation>B-Garden- 2F Hallway</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Hall - BGU</source>
         <comment>70</comment>
         <translation>B-Garden- Hall</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Infirmerie - BGU</source>
         <comment>71</comment>
         <translation>B-Garden- Infirmary</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Dortoirs doubles - BGU</source>
         <comment>72</comment>
         <translation>B-Garden- Dormitory Double</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Dortoirs simples - BGU</source>
         <comment>73</comment>
         <translation>B-Garden- Dormitory Single</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Bureau proviseur - BGU</source>
         <comment>74</comment>
         <translation>B-Garden- Headmaster&apos;s Office</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Parking - BGU</source>
         <comment>75</comment>
         <translation>B-Garden- Parking Lot</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Salle de bal - BGU</source>
         <comment>76</comment>
         <translation>B-Garden- Ballroom</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Campus - BGU</source>
         <comment>77</comment>
         <translation>B-Garden- Quad</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Serre de combat - BGU</source>
         <comment>78</comment>
         <translation>B-Garden- Training Center</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Zone secrète - BGU</source>
         <comment>79</comment>
         <translation>B-Garden- Secret Area</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Corridor - BGU</source>
         <comment>80</comment>
         <translation>B-Garden- Hallway</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Temple - BGU</source>
         <comment>81</comment>
         <translation>B-Garden- Master Room</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Pont - BGU</source>
         <comment>82</comment>
         <translation>B-Garden- Deck</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Villa Dincht - Balamb</source>
         <comment>83</comment>
         <translation>Balamb- The Dincht&apos;s</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Hôtel - Balamb</source>
         <comment>84</comment>
         <translation>Balamb Hotel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Place centrale - Balamb</source>
         <comment>85</comment>
         <translation>Balamb- Town Square</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Place de la gare - Balamb</source>
         <comment>86</comment>
         <translation>Balamb- Station Yard</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Port - Balamb</source>
         <comment>87</comment>
         <translation>Balamb Harbor</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Résidence - Balamb</source>
         <comment>88</comment>
         <translation>Balamb- Residence</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Train</source>
         <comment>89</comment>
         <translation>Train</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Voiture</source>
         <comment>90</comment>
         <translation>Car</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Vaisseau</source>
         <comment>91</comment>
         <translation>Inside Ship</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Mine de souffre</source>
         <comment>92</comment>
         <translation>Fire Cavern</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Place du village - Dollet</source>
         <comment>93</comment>
         <translation>Dollet- Town Square</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Zuma Beach</source>
         <comment>94</comment>
         <translation>Dollet- Lapin Beach</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Port - Dollet</source>
         <comment>95</comment>
         <translation>Dollet Harbor</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Pub - Dollet</source>
         <comment>96</comment>
         <translation>Dollet Pub</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Hôtel - Dollet</source>
         <comment>97</comment>
         <translation>Dollet Hotel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Résidence - Dollet</source>
         <comment>98</comment>
         <translation>Dollet- Residence</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Tour satellite - Dollet</source>
         <comment>99</comment>
         <translation>Dollet- Comm Tower</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Refuge montagneux - Dollet</source>
         <comment>100</comment>
         <translation>Dollet- Mountain Hideout</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Centre ville - Timber</source>
         <comment>101</comment>
         <translation>Timber- City Square</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Chaîne de TV - Timber</source>
         <comment>102</comment>
         <translation>Timber TV Station</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Base des Hiboux - Timber</source>
         <comment>103</comment>
         <translation>Timber- Forest Owls&apos; Base</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Pub - Timber</source>
         <comment>104</comment>
         <translation>Timber Pub</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Hôtel - Timber</source>
         <comment>105</comment>
         <translation>Timber Hotel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Train - Timber</source>
         <comment>106</comment>
         <translation>Timber- Train</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Résidence - Timber</source>
         <comment>107</comment>
         <translation>Timber- Residence</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Ecran géant - Timber</source>
         <comment>108</comment>
         <translation>Timber- TV Screen</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Centre de presse - Timber</source>
         <comment>109</comment>
         <translation>Timber- Editorial Department</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Forêt de Timber</source>
         <comment>110</comment>
         <translation>Timber Forest</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Entrée - Fac de Galbadia</source>
         <comment>111</comment>
         <translation>Galbadia Garden- Front Gate</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Station Fac de Galbadia</source>
         <comment>112</comment>
         <translation>G-Garden- Station</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Hall - Fac de Galbadia</source>
         <comment>113</comment>
         <translation>G-Garden- Hall</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Corridor - Fac de Galbadia</source>
         <comment>114</comment>
         <translation>G-Garden- Hallway</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Salle d&apos;attente - Fac Galbadia</source>
         <comment>115</comment>
         <translation>G-Garden- Reception Room</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Salle de cours - Fac Galbadia</source>
         <comment>116</comment>
         <translation>G-Garden- Classroom</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Salle de réunion - Fac Galbadia</source>
         <comment>117</comment>
         <translation>G-Garden- Clubroom</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Dortoirs - Fac de Galbadia</source>
         <comment>118</comment>
         <translation>G-Garden- Dormitory</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Ascenseur - Fac de Galbadia</source>
         <comment>119</comment>
         <translation>G-Garden- Elevator Hall</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Salle recteur - Fac Galbadia</source>
         <comment>120</comment>
         <translation>G-Garden- Master Room</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Auditorium - Fac de Galbadia</source>
         <comment>121</comment>
         <translation>G-Garden- Auditorium</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Stade - Fac de Galbadia</source>
         <comment>122</comment>
         <translation>G-Garden- Athletic Track</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Stand - Fac de Galbadia</source>
         <comment>123</comment>
         <translation>G-Garden- Stand</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>2nde entrée - Fac Galbadia</source>
         <comment>124</comment>
         <translation>G-Garden- Back Entrance</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Gymnase - Fac de Galbadia</source>
         <comment>125</comment>
         <translation>G-Garden- Gymnasium</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Palais président - Deling City</source>
         <comment>126</comment>
         <translation>Deling- Presidential Residence</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Manoir Caraway - Deling City</source>
         <comment>127</comment>
         <translation>Deling City- Caraway&apos;s Mansion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Gare - Deling City</source>
         <comment>128</comment>
         <translation>Deling City- Station Yard</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Place centrale - Deling City</source>
         <comment>129</comment>
         <translation>Deling City- City Square</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Hôtel - Deling City</source>
         <comment>130</comment>
         <translation>Deling City- Hotel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Bar - Deling City</source>
         <comment>131</comment>
         <translation>Deling City- Club</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Sortie - Deling City</source>
         <comment>132</comment>
         <translation>Deling City- Gateway</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Parade - Deling City</source>
         <comment>133</comment>
         <translation>Deling City- Parade</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Egout - Deling City</source>
         <comment>134</comment>
         <translation>Deling City- Sewer</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Prison du désert - Galbadia</source>
         <comment>135</comment>
         <translation>Galbadia D-District Prison</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Désert</source>
         <comment>136</comment>
         <translation>Desert</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Base des missiles</source>
         <comment>137</comment>
         <translation>Galbadia Missile Base</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Village de Winhill</source>
         <comment>138</comment>
         <translation>Winhill Village</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Pub - Winhill</source>
         <comment>139</comment>
         <translation>Winhill Pub</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Maison vide - Winhill</source>
         <comment>140</comment>
         <translation>Winhill- Vacant House</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Manoir - Winhill</source>
         <comment>141</comment>
         <translation>Winhill- Mansion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Résidence - Winhill</source>
         <comment>142</comment>
         <translation>Winhill- Residence</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Hôtel - Winhill</source>
         <comment>143</comment>
         <translation>Winhill- Hotel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Voiture - Winhill</source>
         <comment>144</comment>
         <translation>Winhill- Car</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Tombe du roi inconnu</source>
         <comment>145</comment>
         <translation>Tomb of the Unknown King</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Horizon</source>
         <comment>146</comment>
         <translation>Fishermans Horizon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Habitations - Horizon</source>
         <comment>147</comment>
         <translation>FH- Residential Area</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Ecrans solaires - Horizon</source>
         <comment>148</comment>
         <translation>FH- Sun Panel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Villa du maire - Horizon</source>
         <comment>149</comment>
         <translation>FH- Mayor&apos;s Residence</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Usine - Horizon</source>
         <comment>150</comment>
         <translation>FH- Factory</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Salle des fêtes - Horizon</source>
         <comment>151</comment>
         <translation>FH- Festival Grounds</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Hôtel - Horizon</source>
         <comment>152</comment>
         <translation>FH- Hotel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Résidence - Horizon</source>
         <comment>153</comment>
         <translation>FH- Residence</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Gare - Horizon</source>
         <comment>154</comment>
         <translation>FH- Station Yard</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Aqueduc d&apos;Horizon</source>
         <comment>155</comment>
         <translation>FH- Horizon Bridge</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Station balnéaire</source>
         <comment>156</comment>
         <translation>FH- Seaside Station</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Salt Lake</source>
         <comment>157</comment>
-        <translation>FH- Geat Salt Lake</translation>
+        <translation>FH- Great Salt Lake</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Bâtiment mystérieux</source>
         <comment>158</comment>
         <translation>FH- Mystery Building</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Esthar City</source>
         <comment>159</comment>
         <translation>Esthar- City</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Laboratoire Geyser - Esthar</source>
         <comment>160</comment>
         <translation>Esthar- Odine&apos;s Laboratory</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Aérodrome - Esthar</source>
         <comment>161</comment>
         <translation>Esthar- Airstation</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Lunatic Pandora approche</source>
         <comment>162</comment>
         <translation>Lunatic Pandora Approaching</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Résidence président - Esthar</source>
         <comment>163</comment>
         <translation>Esthar- Presidential Palace</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Hall - Résidence président</source>
         <comment>164</comment>
         <translation>Presidential Palace- Hall</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Couloir - Résidence président</source>
         <comment>165</comment>
         <translation>Presidential Palace- Hallway</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Bureau - Résidence président</source>
         <comment>166</comment>
         <translation>Presidential Palace- Office</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Accueil - Labo Geyser</source>
         <comment>167</comment>
         <translation>Dr. Odine&apos;s Laboratory- Lobby</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Laboratoire Geyser</source>
         <comment>168</comment>
         <translation>Dr. Odine&apos;s Laboratory- Lab</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Deleted</source>
         <comment>169</comment>
         <translation>Deleted</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Lunar Gate</source>
         <comment>170</comment>
         <translation>Lunar Gate</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Parvis - Lunar Gate</source>
         <comment>171</comment>
         <translation>Lunar Gate- Concourse</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Glacière - Lunar gate</source>
         <comment>172</comment>
         <translation>Lunar Gate- Deep Freeze</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Mausolée - Esthar</source>
         <comment>173</comment>
         <translation>Esthar Sorceress Memorial</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Entrée - Mausolée</source>
         <comment>174</comment>
         <translation>Sorceress Memorial- Entrance</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Pod de confinement - Mausolée</source>
         <comment>175</comment>
         <translation>Sorceress Memorial- Pod</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Salle de contrôle - Mausolée</source>
         <comment>176</comment>
         <translation>Sorceress Memorial- Ctrl Room</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Tears Point</source>
         <comment>177</comment>
         <translation>Tears&apos; Point</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Labo Lunatic Pandora</source>
         <comment>178</comment>
         <translation>Lunatic Pandora Laboratory</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Zone d&apos;atterrissage de secours</source>
         <comment>179</comment>
         <translation>Emergency Landing Zone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Zone d&apos;atterrissage officielle</source>
         <comment>180</comment>
         <translation>Spaceship Landing Zone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Lunatic Pandora</source>
         <comment>181</comment>
         <translation>Lunatic Pandora</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Site des fouilles - Centra</source>
         <comment>182</comment>
         <translation>Centra- Excavation Site</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Orphelinat</source>
         <comment>183</comment>
         <translation>Edea&apos;s House</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Salle de jeux - Orphelinat</source>
         <comment>184</comment>
         <translation>Edea&apos;s House- Playroom</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Dortoir - Orphelinat</source>
         <comment>185</comment>
         <translation>Edea&apos;s House- Bedroom</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Jardin - Orphelinat</source>
         <comment>186</comment>
         <translation>Edea&apos;s House- Backyard</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Front de mer - Orphelinat</source>
         <comment>187</comment>
         <translation>Edea&apos;s House- Oceanside</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Champ - Orphelinat</source>
         <comment>188</comment>
         <translation>Edea&apos;s House- Flower Field</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Ruines de Centra</source>
         <comment>189</comment>
         <translation>Centra Ruins</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Entrée - Fac de Trabia</source>
         <comment>190</comment>
         <translation>Trabia Garden- Front Gate</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Cimetière - Fac de Trabia</source>
         <comment>191</comment>
         <translation>T-Garden- Cemetery</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Garage - Fac de Trabia</source>
         <comment>192</comment>
         <translation>T-Garden- Garage</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Campus - Fac Trabia</source>
         <comment>193</comment>
         <translation>T-Garden- Festival Stage</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Amphithéatre - Fac de Trabia</source>
         <comment>194</comment>
         <translation>T-Garden- Classroom</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Stade - Fac de Trabia</source>
         <comment>195</comment>
         <translation>T-Garden- Athletic Ground</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Dôme mystérieux</source>
         <comment>196</comment>
         <translation>Mystery Dome</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Ville du désert - Shumi Village</source>
         <comment>197</comment>
         <translation>Shumi Village- Desert Village</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Ascenseur - Shumi Village</source>
         <comment>198</comment>
         <translation>Shumi Village- Elevator</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Shumi Village</source>
         <comment>199</comment>
         <translation>Shumi Village- Village</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Habitation - Shumi Village</source>
         <comment>200</comment>
         <translation>Shumi Village- Residence</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Résidence - Shumi Village</source>
         <comment>201</comment>
         <translation>Shumi Village- Residence</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Habitat - Shumi Village</source>
         <comment>202</comment>
         <translation>Shumi Village- Residence</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Hôtel - Shumi Village</source>
         <comment>203</comment>
         <translation>Shumi Village- Hotel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Trabia canyon</source>
         <comment>204</comment>
         <translation>Trabia Canyon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Vaisseau des Seeds blancs</source>
         <comment>205</comment>
         <translation>White SeeD Ship</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Navire des Seeds Blancs</source>
         <comment>206</comment>
         <translation>White SeeD Ship</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Cabine - Navire Seeds blancs</source>
         <comment>207</comment>
         <translation>White SeeD Ship- Cabin</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Cockpit - Hydre</source>
         <comment>208</comment>
         <translation>Ragnarok- Cockpit</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Siège passager - Hydre</source>
         <comment>209</comment>
         <translation>Ragnarok- Passenger Seat</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Couloir - Hydre</source>
         <comment>210</comment>
         <translation>Ragnarok- Aisle</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Hangar - Hydre</source>
         <comment>211</comment>
         <translation>Ragnarok- Hangar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Accès - Hydre</source>
         <comment>212</comment>
         <translation>Ragnarok- Entrance</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Air Room - Hydre</source>
         <comment>213</comment>
         <translation>Ragnarok- Air Room</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Salle de pression - Hydre</source>
         <comment>214</comment>
         <translation>Ragnarok- Space Hatch</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Centre de recherches Deep Sea</source>
         <comment>215</comment>
         <translation>Deep Sea Research Center</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Laboratoire - Deep Sea</source>
         <comment>216</comment>
         <translation>Deep Sea Research Center- Lb</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Salle de travail - Deep Sea</source>
         <comment>217</comment>
         <translation>Deep Sea Research Center- Lv</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Fouilles - Deep Sea</source>
         <comment>218</comment>
         <translation>Deep Sea Deposit</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Salle de contrôle - Base lunaire</source>
         <comment>219</comment>
         <translation>Lunar Base- Control Room</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Centre médical - Base lunaire</source>
         <comment>220</comment>
         <translation>Lunar Base- Medical Room</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Pod - Base lunaire</source>
         <comment>221</comment>
         <translation>Lunar Base- Pod</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Dock - Base lunaire</source>
         <comment>222</comment>
         <translation>Lunar Base- Dock</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Passage - Base lunaire</source>
         <comment>223</comment>
         <translation>Lunar Base- Passageway</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Vestiaire - Base lunaire</source>
         <comment>224</comment>
         <translation>Lunar Base- Locker</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Habitats - Base lunaire</source>
         <comment>225</comment>
         <translation>Lunar Base- Residential Zone</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Hyper Espace</source>
         <comment>226</comment>
         <translation>Outer Space</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Forêt Chocobo</source>
         <comment>227</comment>
         <translation>Chocobo Forest</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Jungle</source>
         <comment>228</comment>
         <translation>Wilderness</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Citadelle d&apos;Ultimecia - Vestibule</source>
         <comment>229</comment>
         <translation>Ultimecia Castle- Hall</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Citadelle d&apos;Ultimecia - Hall</source>
         <comment>230</comment>
         <translation>Ultimecia Castle- Grand Hall</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Citadelle d&apos;Ultimecia - Terrasse</source>
         <comment>231</comment>
         <translation>Ultimecia Castle- Terrace</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Citadelle d&apos;Ultimecia - Cave</source>
         <comment>232</comment>
         <translation>Ultimecia Castle- Wine Cellar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Citadelle d&apos;Ultimecia - Couloir</source>
         <comment>233</comment>
         <translation>Ultimecia Castle- Passageway</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Elévateur - Citadelle</source>
         <comment>234</comment>
         <translation>Ultimecia Castle- Elevator Hall</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Escalier - Citadelle d&apos;Ultimecia</source>
         <comment>235</comment>
         <translation>Ultimecia Castle- Stairway Hall</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Salle du trésor - Citadelle</source>
         <comment>236</comment>
         <translation>Ultimecia Castle- Treasure Rm</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Salle de rangement - Citadelle</source>
         <comment>237</comment>
         <translation>Ultimecia Castle- Storage Room</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Citadelle d&apos;Ultimecia - Galerie</source>
         <comment>238</comment>
         <translation>Ultimecia Castle- Art Gallery</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Citadelle d&apos;Ultimecia - Ecluse</source>
         <comment>239</comment>
         <translation>Ultimecia Castle- Flood Gate</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Citadelle - Armurerie</source>
         <comment>240</comment>
         <translation>Ultimecia Castle- Armory</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Citadelle d&apos;Ultimecia - Prison</source>
         <comment>241</comment>
         <translation>Ultimecia Castle- Prison Cell</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Citadelle d&apos;Ultimecia - Fossé</source>
         <comment>242</comment>
         <translation>Ultimecia Castle- Waterway</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Citadelle d&apos;Ultimecia - Jardin</source>
         <comment>243</comment>
         <translation>Ultimecia Castle- Courtyard</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Citadelle d&apos;Ultimecia - Chapelle</source>
         <comment>244</comment>
         <translation>Ultimecia Castle- Chapel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Clocher - Citadelle d&apos;Ultimecia</source>
         <comment>245</comment>
         <translation>Ultimecia Castle- Clock Tower</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Chambre d&apos;Ultimecia - Citadelle</source>
         <comment>246</comment>
         <translation>Ultimecia Castle- Master Room</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Citadelle d&apos;Ultimecia</source>
         <comment>248</comment>
         <translation>Ultimecia Castle</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Salle d&apos;initiation</source>
         <comment>249</comment>
         <translation>Commencement Room</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Reine des cartes</source>
         <comment>250</comment>
         <translation>Queen</translation>
     </message>
     <message>
+        <location filename="Data.cpp" line="142"/>
+        <source>Balamb City</source>
+        <translation>Balamb City</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="142"/>
+        <source>Deling City</source>
+        <translation>Deling City</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="142"/>
+        <source>Shumi Village</source>
+        <translation>Shumi Village</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="143"/>
+        <source>Winhill</source>
+        <translation>Winhill</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="143"/>
+        <source>Dollet</source>
+        <translation>Dollet</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="143"/>
+        <source>Horizon</source>
+        <translation>Fishermans Horizon</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="144"/>
+        <source>Lunar Gate</source>
+        <translation>Lunar Gate</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="144"/>
+        <source>Esthar City</source>
+        <translation>Esthar City</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="144"/>
+        <source>Timber</source>
+        <translation>Timber</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="145"/>
+        <source>BGU</source>
+        <translation>Balamb Garden</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="145"/>
+        <source>GGU</source>
+        <translation>Galbadia Garden</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="145"/>
+        <source>TGU</source>
+        <translation>Trabia Garden</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="145"/>
+        <source>Ruines de Centra</source>
+        <translation>Centra Ruins</translation>
+    </message>
+    <message>
         <location filename="Data.cpp" line="146"/>
+        <source>Orphelinat</source>
+        <translation>Edea&apos;s House</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="146"/>
+        <source>Salt Lake</source>
+        <translation>Great Salt Lake</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="146"/>
+        <source>Forêt des novices</source>
+        <translation>Beginner&apos;s Forest</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="147"/>
+        <source>Forêt Classica</source>
+        <translation>Basic Forest</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="147"/>
+        <source>Forêt de l&apos;errance</source>
+        <translation>Roaming Forest</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="147"/>
+        <source>Sanctuaire des chocobos</source>
+        <translation>Chocobo Sanctuary</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="148"/>
+        <source>Forêt clôturée</source>
+        <translation>Enclosed Forest</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="148"/>
+        <source>Forêt fun</source>
+        <translation>Fun Forest</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="148"/>
+        <source>Forêt de la solitude</source>
+        <translation>Forest of Solitude</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="149"/>
+        <source>Pod de secours</source>
+        <translation>Landing site</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="159"/>
         <source>Sagaie</source>
         <translation>Strange Vision</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="154"/>
+        <location filename="Data.cpp" line="167"/>
         <source>Boko</source>
         <translation>Boko</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="167"/>
+        <location filename="Data.cpp" line="180"/>
         <source>Feinte</source>
         <translation>Booya</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="167"/>
+        <location filename="Data.cpp" line="180"/>
         <source>Achille</source>
         <translation>Heel Drop</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="167"/>
+        <location filename="Data.cpp" line="180"/>
         <source>Forcing</source>
         <translation>Mach Kick</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="167"/>
+        <location filename="Data.cpp" line="180"/>
         <source>Delphinium</source>
         <translation>Dolphin Blow</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="168"/>
+        <location filename="Data.cpp" line="181"/>
         <source>Apesanteur</source>
         <translation>Meteor Strike</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="168"/>
+        <location filename="Data.cpp" line="181"/>
         <source>Fahreinheit</source>
         <translation>Burning Rave</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="168"/>
+        <location filename="Data.cpp" line="181"/>
         <source>Stratosphère</source>
         <translation>Meteor Barret</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="168"/>
+        <location filename="Data.cpp" line="181"/>
         <source>Trapèze</source>
         <translation>Different Beat</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="168"/>
+        <location filename="Data.cpp" line="181"/>
         <source>Global Wave</source>
         <translation>My Final Heaven</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="173"/>
+        <location filename="Data.cpp" line="186"/>
         <source>Furioso</source>
         <translation>Normal Shot</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="173"/>
+        <location filename="Data.cpp" line="186"/>
         <source>Fluxion</source>
         <translation>Scatter Shot</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="173"/>
+        <location filename="Data.cpp" line="186"/>
         <source>Fracas</source>
         <translation>Dark Shot</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="173"/>
+        <location filename="Data.cpp" line="186"/>
         <source>Fusion</source>
         <translation>Flame Shot</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="174"/>
+        <location filename="Data.cpp" line="187"/>
         <source>Barbacane</source>
         <translation>Canister Shot</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="174"/>
+        <location filename="Data.cpp" line="187"/>
         <source>Mach 4</source>
         <translation>Quick Shot</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="174"/>
+        <location filename="Data.cpp" line="187"/>
         <source>Apogée</source>
         <translation>Armor Shot</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="174"/>
+        <location filename="Data.cpp" line="187"/>
         <source>Percuteur</source>
         <translation>Hyper Shot</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="179"/>
+        <location filename="Data.cpp" line="192"/>
         <source>Fovéa</source>
         <translation>Laser Eye</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="179"/>
+        <location filename="Data.cpp" line="192"/>
         <source>Ultra Waves</source>
         <translation>Ultra Waves</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="179"/>
+        <location filename="Data.cpp" line="192"/>
         <source>Firmament</source>
         <translation>Electrocute</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="179"/>
+        <location filename="Data.cpp" line="192"/>
         <source>Freak</source>
         <translation>LV?Death</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="180"/>
+        <location filename="Data.cpp" line="193"/>
         <source>Dégénérator</source>
         <translation>Degenerator</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="180"/>
+        <location filename="Data.cpp" line="193"/>
         <source>Fréon</source>
         <translation>Aqua Breath</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="180"/>
+        <location filename="Data.cpp" line="193"/>
         <source>Micro Missiles</source>
         <translation>Micro Missiles</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="180"/>
+        <location filename="Data.cpp" line="193"/>
         <source>Acid</source>
         <translation>Acid</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="181"/>
+        <location filename="Data.cpp" line="194"/>
         <source>Mitraille</source>
         <translation>Gatling Gun</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="181"/>
+        <location filename="Data.cpp" line="194"/>
         <source>Dead Heat</source>
         <translation>Fire Breath</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="181"/>
+        <location filename="Data.cpp" line="194"/>
         <source>Infection</source>
         <translation>Bad Breath</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="181"/>
+        <location filename="Data.cpp" line="194"/>
         <source>Mistral</source>
         <translation>White Wind</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="182"/>
+        <location filename="Data.cpp" line="195"/>
         <source>Laser</source>
         <translation>Homing Laser</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="182"/>
+        <location filename="Data.cpp" line="195"/>
         <source>Mother</source>
         <translation>Mighty Guard</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="182"/>
+        <location filename="Data.cpp" line="195"/>
         <source>Shockwave</source>
         <translation>Ray-Bomb</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="182"/>
+        <location filename="Data.cpp" line="195"/>
         <source>Outerspace</source>
         <translation>Shockwave Pulsar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="187"/>
+        <location filename="Data.cpp" line="200"/>
         <source>Dingo</source>
         <translation>Rush</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="187"/>
+        <location filename="Data.cpp" line="200"/>
         <source>Shepherd</source>
         <translation>Recover</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="187"/>
+        <location filename="Data.cpp" line="200"/>
         <source>Dachshund</source>
         <translation>Reverse</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="187"/>
+        <location filename="Data.cpp" line="200"/>
         <source>Borzoï</source>
         <translation>Search</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="188"/>
+        <location filename="Data.cpp" line="201"/>
         <source>Laïka</source>
         <translation>Cannon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="188"/>
+        <location filename="Data.cpp" line="201"/>
         <source>Nordfolk</source>
         <translation>Strike</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="188"/>
+        <location filename="Data.cpp" line="201"/>
         <source>Sélénium</source>
         <translation>Invincible Moon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="188"/>
+        <location filename="Data.cpp" line="201"/>
         <source>Phantasm</source>
         <translation>Wishing Star</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="193"/>
+        <location filename="Data.cpp" line="206"/>
         <source>Bogomile</source>
         <translation>Geezard</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="193"/>
+        <location filename="Data.cpp" line="206"/>
         <source>Fungus</source>
         <translation>Funguar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="193"/>
+        <location filename="Data.cpp" line="206"/>
         <source>Elmidea</source>
         <translation>Bite Bug</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="193"/>
+        <location filename="Data.cpp" line="206"/>
         <source>Nocturnus</source>
         <translation>Red Bat</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="193"/>
+        <location filename="Data.cpp" line="206"/>
         <source>Incube</source>
         <translation>Blobra</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="193"/>
+        <location filename="Data.cpp" line="206"/>
         <source>Aphide</source>
         <translation>Gayla</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="194"/>
+        <location filename="Data.cpp" line="207"/>
         <source>Elastos</source>
         <translation>Gesper</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="194"/>
+        <location filename="Data.cpp" line="207"/>
         <source>Diodon</source>
         <translation>Fastitocalon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="194"/>
+        <location filename="Data.cpp" line="207"/>
         <source>Carnidéa</source>
         <translation>Blood Soul</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="194"/>
+        <location filename="Data.cpp" line="207"/>
         <source>Larva</source>
         <translation>Caterchipillar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="194"/>
+        <location filename="Data.cpp" line="207"/>
         <source>Gallus</source>
         <translation>Cockatrice</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="194"/>
+        <location filename="Data.cpp" line="207"/>
         <source>Orchida</source>
         <translation>Grat</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="195"/>
+        <location filename="Data.cpp" line="208"/>
         <source>Schizoïd</source>
         <translation>Buel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="195"/>
+        <location filename="Data.cpp" line="208"/>
         <source>Licorne</source>
         <translation>Mesmerize</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="195"/>
+        <location filename="Data.cpp" line="208"/>
         <source>Koatl</source>
         <translation>Belhelmel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="195"/>
+        <location filename="Data.cpp" line="208"/>
         <source>Malaku</source>
         <translation>Thrustaevis</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="195"/>
+        <location filename="Data.cpp" line="208"/>
         <source>Arconada</source>
         <translation>Anacondaur</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="195"/>
+        <location filename="Data.cpp" line="208"/>
         <source>Xylopode</source>
         <translation>Glacial Eye</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="196"/>
+        <location filename="Data.cpp" line="209"/>
         <source>Formicide</source>
         <translation>Creeps</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="196"/>
+        <location filename="Data.cpp" line="209"/>
         <source>Feng</source>
         <translation>Grendel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="196"/>
+        <location filename="Data.cpp" line="209"/>
         <source>Héra</source>
         <translation>Jelleye</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="196"/>
+        <location filename="Data.cpp" line="209"/>
         <source>Selek</source>
         <translation>Grand Mantis</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="196"/>
+        <location filename="Data.cpp" line="209"/>
         <source>Weevil</source>
         <translation>Forbidden</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="196"/>
+        <location filename="Data.cpp" line="209"/>
         <source>Scavenger</source>
         <translation>Armadodo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="197"/>
+        <location filename="Data.cpp" line="210"/>
         <source>Adéphage</source>
         <translation>Tri-Face</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="197"/>
+        <location filename="Data.cpp" line="210"/>
         <source>Phantom</source>
         <translation>Fastitocalon-F</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="197"/>
+        <location filename="Data.cpp" line="210"/>
         <source>Satyrux</source>
         <translation>Snow Lion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="197"/>
+        <location filename="Data.cpp" line="210"/>
         <source>Trogiidae</source>
         <translation>Ochu</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="197"/>
+        <location filename="Data.cpp" line="210"/>
         <source>Barbarian</source>
         <translation>SAM08G</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="198"/>
+        <location filename="Data.cpp" line="211"/>
         <source>Célébis</source>
         <translation>Abyss Worm</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="198"/>
+        <location filename="Data.cpp" line="211"/>
         <source>Eiffel</source>
         <translation>Turtapod</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="198"/>
+        <location filename="Data.cpp" line="211"/>
         <source>Cariatide</source>
         <translation>Vysage</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="198"/>
+        <location filename="Data.cpp" line="211"/>
         <source>Pampa</source>
         <comment>card</comment>
         <translation>Cactuar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="198"/>
+        <location filename="Data.cpp" line="211"/>
         <source>Tomberry</source>
         <comment>card</comment>
         <translation>Tonberry</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="198"/>
+        <location filename="Data.cpp" line="211"/>
         <source>Berserker</source>
         <translation>Death Claw</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="199"/>
+        <location filename="Data.cpp" line="212"/>
         <source>T-rex</source>
         <translation>T-Rexaur</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="199"/>
+        <location filename="Data.cpp" line="212"/>
         <source>Succube</source>
         <translation>Bomb</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="199"/>
+        <location filename="Data.cpp" line="212"/>
         <source>Tikal</source>
         <translation>Blitz</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="199"/>
+        <location filename="Data.cpp" line="212"/>
         <source>Wendigo</source>
         <translation>Wendigo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="199"/>
+        <location filename="Data.cpp" line="212"/>
         <source>Marsupial</source>
         <translation>Torama</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="199"/>
+        <location filename="Data.cpp" line="212"/>
         <source>Draconus</source>
         <translation>Imp</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="200"/>
+        <location filename="Data.cpp" line="213"/>
         <source>Moloch</source>
         <translation>Blue Dragon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="200"/>
+        <location filename="Data.cpp" line="213"/>
         <source>Ao</source>
         <translation>Adamantoise</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="200"/>
+        <location filename="Data.cpp" line="213"/>
         <source>Polyphage</source>
         <translation>Hexadragon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="200"/>
+        <location filename="Data.cpp" line="213"/>
         <source>Ekarissor</source>
         <translation>Iron Giant</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="200"/>
+        <location filename="Data.cpp" line="213"/>
         <source>Kanibal</source>
         <translation>Behemoth</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="200"/>
+        <location filename="Data.cpp" line="213"/>
         <source>Chimaira</source>
         <translation>Chimera</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="201"/>
+        <location filename="Data.cpp" line="214"/>
         <source>Koyo K</source>
         <translation>PuPu</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="201"/>
+        <location filename="Data.cpp" line="214"/>
         <source>Protesis</source>
         <translation>Elastoid</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="201"/>
+        <location filename="Data.cpp" line="214"/>
         <source>Pikasso</source>
         <translation>GIM47N</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="201"/>
+        <location filename="Data.cpp" line="214"/>
         <source>Xylomid</source>
         <translation>Malboro</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="201"/>
+        <location filename="Data.cpp" line="214"/>
         <source>Griffon</source>
         <translation>Ruby Dragon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="201"/>
+        <location filename="Data.cpp" line="214"/>
         <source>Sulfor</source>
         <translation>Elnoyle</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="202"/>
+        <location filename="Data.cpp" line="215"/>
         <source>Tomberry Sr</source>
         <translation>Tonberry King</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="202"/>
+        <location filename="Data.cpp" line="215"/>
         <source>Wedge/Biggs</source>
         <translation>Wedge, Biggs</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="202"/>
+        <location filename="Data.cpp" line="215"/>
         <source>Fujin/Raijin</source>
         <translation>Fujin, Raijin</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="202"/>
+        <location filename="Data.cpp" line="215"/>
         <source>Sulfura</source>
         <translation>Elvoret</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="202"/>
+        <location filename="Data.cpp" line="215"/>
         <source>Goliath</source>
         <translation>X-ATM092</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="203"/>
+        <location filename="Data.cpp" line="216"/>
         <source>Lygus</source>
         <translation>Granaldo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="203"/>
+        <location filename="Data.cpp" line="216"/>
         <source>Écorché</source>
         <translation>Gerogero</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="203"/>
+        <location filename="Data.cpp" line="216"/>
         <source>Iguanor</source>
         <translation>Iguion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="203"/>
+        <location filename="Data.cpp" line="216"/>
         <source>Hornet</source>
         <translation>Abadon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="203"/>
+        <location filename="Data.cpp" line="216"/>
         <source>Flotix</source>
         <translation>Trauma</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="203"/>
+        <location filename="Data.cpp" line="216"/>
         <source>Cyanide</source>
         <translation>Oilboyle</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="204"/>
+        <location filename="Data.cpp" line="217"/>
         <source>Shumi</source>
         <translation>Shumi</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="204"/>
+        <location filename="Data.cpp" line="217"/>
         <source>Krystal</source>
         <translation>Krysta</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="204"/>
+        <location filename="Data.cpp" line="217"/>
         <source>Alienator</source>
         <translation>Propagator</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="204"/>
+        <location filename="Data.cpp" line="217"/>
         <source>Pampa Sr</source>
         <translation>Jumbo Cactuar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="204"/>
+        <location filename="Data.cpp" line="217"/>
         <source>Acron</source>
         <translation>Tri-Point</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="204"/>
+        <location filename="Data.cpp" line="217"/>
         <source>Agamemnon</source>
         <translation>Gargantua</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="205"/>
+        <location filename="Data.cpp" line="218"/>
         <source>Anakronox</source>
         <translation>Mobile Type 8</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="205"/>
+        <location filename="Data.cpp" line="218"/>
         <source>Mithra</source>
         <translation>Sphinxara</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="205"/>
+        <location filename="Data.cpp" line="218"/>
         <source>Acarnan</source>
         <translation>Tiamat</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="205"/>
+        <location filename="Data.cpp" line="218"/>
         <source>Omniborg</source>
         <translation>BGH251F2</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="205"/>
+        <location filename="Data.cpp" line="218"/>
         <source>Attila</source>
         <translation>Red Giant</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="205"/>
+        <location filename="Data.cpp" line="218"/>
         <source>Fabryce</source>
         <translation>Catoblepas</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="206"/>
+        <location filename="Data.cpp" line="219"/>
         <source>Monarch</source>
         <translation>Ultima Weapon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="216"/>
+        <location filename="Data.cpp" line="229"/>
         <source>Dummy</source>
         <comment>Ennemy</comment>
         <translation>Dummy</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="216"/>
+        <location filename="Data.cpp" line="229"/>
         <source>ExoSkelet</source>
         <comment>Ennemy</comment>
         <translation>GIM52A</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="216"/>
+        <location filename="Data.cpp" line="229"/>
         <source>Incube</source>
         <comment>Ennemy</comment>
         <translation>Blobra</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="216"/>
+        <location filename="Data.cpp" line="229"/>
         <source>Malaku</source>
         <comment>Ennemy</comment>
         <translation>Thrustaevis</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="217"/>
+        <location filename="Data.cpp" line="230"/>
         <source>Bogomile</source>
         <comment>Ennemy</comment>
         <translation>Geezard</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="217"/>
+        <location filename="Data.cpp" line="230"/>
         <source>Koatl</source>
         <comment>Ennemy</comment>
         <translation>Belhelmel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="217"/>
+        <location filename="Data.cpp" line="230"/>
         <source>Xylopode</source>
         <comment>Ennemy</comment>
         <translation>Glacial Eye</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="217"/>
+        <location filename="Data.cpp" line="230"/>
         <source>Barbarian</source>
         <comment>Ennemy</comment>
         <translation>SAM08G</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="218"/>
+        <location filename="Data.cpp" line="231"/>
         <source>Pikasso</source>
         <comment>Ennemy</comment>
         <translation>GIM47N</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="218"/>
+        <location filename="Data.cpp" line="231"/>
         <source>Licorne</source>
         <comment>Ennemy</comment>
         <translation>Mesmerize</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="218"/>
+        <location filename="Data.cpp" line="231"/>
         <source>Schizoïd</source>
         <comment>Ennemy</comment>
         <translation>Buel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="218"/>
+        <location filename="Data.cpp" line="231"/>
         <source>Brahman</source>
         <comment>Ennemy</comment>
         <translation>Sphinxaur</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="219"/>
+        <location filename="Data.cpp" line="232"/>
         <source>Shiva</source>
         <comment>Ennemy</comment>
         <translation>Sphinxara</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="219"/>
+        <location filename="Data.cpp" line="232"/>
         <source>Satyrux</source>
         <comment>Ennemy</comment>
         <translation>Snow Lion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="219"/>
+        <location filename="Data.cpp" line="232"/>
         <source>Arconada</source>
         <comment>Ennemy</comment>
         <translation>Anacondaur</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="219"/>
+        <location filename="Data.cpp" line="232"/>
         <source>Orchida</source>
         <comment>Ennemy</comment>
         <translation>Grat</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="220"/>
+        <location filename="Data.cpp" line="233"/>
         <source>Gallus</source>
         <comment>Ennemy</comment>
         <translation>Cockatrice</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="220"/>
+        <location filename="Data.cpp" line="233"/>
         <source>Larva</source>
         <comment>Ennemy</comment>
         <translation>Caterchipillar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="220"/>
+        <location filename="Data.cpp" line="233"/>
         <source>Nocturnus</source>
         <comment>Ennemy</comment>
         <translation>Red Bat</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="220"/>
+        <location filename="Data.cpp" line="233"/>
         <source>Tikal</source>
         <comment>Ennemy</comment>
         <translation>Blitz</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="221"/>
+        <location filename="Data.cpp" line="234"/>
         <source>Diodon</source>
         <comment>Ennemy</comment>
         <translation>Fastitocalon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="221"/>
+        <location filename="Data.cpp" line="234"/>
         <source>Phantom</source>
         <comment>Ennemy</comment>
         <translation>Fastitocalon-F</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="221"/>
+        <location filename="Data.cpp" line="234"/>
         <source>Elastos</source>
         <comment>Ennemy</comment>
         <translation>Gesper</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="221"/>
+        <location filename="Data.cpp" line="234"/>
         <source>Formicide</source>
         <comment>Ennemy</comment>
         <translation>Creeps</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="222"/>
+        <location filename="Data.cpp" line="235"/>
         <source>Polyphage</source>
         <comment>Ennemy</comment>
         <translation>Hexadragon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="222"/>
+        <location filename="Data.cpp" line="235"/>
         <source>Carnidea</source>
         <comment>Ennemy</comment>
         <translation>Blood Soul</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="222"/>
+        <location filename="Data.cpp" line="235"/>
         <source>Protesis</source>
         <comment>Ennemy</comment>
         <translation>Elastoid</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="222"/>
+        <location filename="Data.cpp" line="235"/>
         <source>Scavenger</source>
         <comment>Ennemy</comment>
         <translation>Armadodo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="223"/>
+        <location filename="Data.cpp" line="236"/>
         <source>Elmidea</source>
         <comment>Ennemy</comment>
         <translation>Bite Bug</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="223"/>
+        <location filename="Data.cpp" line="236"/>
         <source>Héra</source>
         <comment>Ennemy</comment>
         <translation>Jelleye</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="223"/>
+        <location filename="Data.cpp" line="236"/>
         <source>Acron</source>
         <comment>Ennemy</comment>
         <translation>Tri-Point</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="223"/>
+        <location filename="Data.cpp" line="236"/>
         <source>Eiffel</source>
         <comment>Ennemy</comment>
         <translation>Turtapod</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="224"/>
+        <location filename="Data.cpp" line="237"/>
         <source>Wendigo</source>
         <comment>Ennemy</comment>
         <translation>Wendigo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="224"/>
+        <location filename="Data.cpp" line="237"/>
         <source>Aphide</source>
         <comment>Ennemy</comment>
         <translation>Gayla</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="224"/>
+        <location filename="Data.cpp" line="237"/>
         <source>Ecorché</source>
         <comment>Ennemy</comment>
         <translation>Gerogero</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="224"/>
+        <location filename="Data.cpp" line="237"/>
         <source>Berserker</source>
         <comment>Ennemy</comment>
         <translation>Death Claw</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="225"/>
+        <location filename="Data.cpp" line="238"/>
         <source>Adéphage</source>
         <comment>Ennemy</comment>
         <translation>Tri-Face</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="225"/>
+        <location filename="Data.cpp" line="238"/>
         <source>Selek</source>
         <comment>Ennemy</comment>
         <translation>Grand Mantis</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="225"/>
+        <location filename="Data.cpp" line="238"/>
         <source>Krystal</source>
         <comment>Ennemy</comment>
         <translation>Krysta</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="225"/>
+        <location filename="Data.cpp" line="238"/>
         <source>Gangrène</source>
         <comment>Ennemy</comment>
         <translation>Lefty</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="226"/>
+        <location filename="Data.cpp" line="239"/>
         <source>Fatima</source>
         <comment>Ennemy</comment>
         <translation>Righty</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="226"/>
+        <location filename="Data.cpp" line="239"/>
         <source>Moloch</source>
         <comment>Ennemy</comment>
         <translation>Blue Dragon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="226"/>
+        <location filename="Data.cpp" line="239"/>
         <source>Weevil</source>
         <comment>Ennemy</comment>
         <translation>Forbidden</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="226"/>
+        <location filename="Data.cpp" line="239"/>
         <source>Succube</source>
         <comment>Ennemy</comment>
         <translation>Bomb</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="227"/>
+        <location filename="Data.cpp" line="240"/>
         <source>Célébis</source>
         <comment>Ennemy</comment>
         <translation>Abyss Worm</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="227"/>
+        <location filename="Data.cpp" line="240"/>
         <source>Trogiidae</source>
         <comment>Ennemy</comment>
         <translation>Ochu</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="227"/>
+        <location filename="Data.cpp" line="240"/>
         <source>Ao</source>
         <comment>Ennemy</comment>
         <translation>Adamantoise</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="227"/>
+        <location filename="Data.cpp" line="240"/>
         <source>Chimaira</source>
         <comment>Ennemy</comment>
         <translation>Chimera</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="228"/>
+        <location filename="Data.cpp" line="241"/>
         <source>Xylomid</source>
         <comment>Ennemy</comment>
         <translation>Malboro</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="228"/>
+        <location filename="Data.cpp" line="241"/>
         <source>Ekarissor</source>
         <comment>Ennemy</comment>
         <translation>Iron Giant</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="228"/>
+        <location filename="Data.cpp" line="241"/>
         <source>Kanibal</source>
         <comment>Ennemy</comment>
         <translation>Behemoth</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="228"/>
+        <location filename="Data.cpp" line="241"/>
         <source>T-Rex</source>
         <comment>Ennemy</comment>
         <translation>T-Rexaur</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="229"/>
+        <location filename="Data.cpp" line="242"/>
         <source>Griffon</source>
         <comment>Ennemy</comment>
         <translation>Ruby Dragon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="229"/>
+        <location filename="Data.cpp" line="242"/>
         <source>Feng</source>
         <comment>Ennemy</comment>
         <translation>Grendel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="229"/>
+        <location filename="Data.cpp" line="242"/>
         <source>Cariatide</source>
         <comment>Ennemy</comment>
         <translation>Vysage</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="229"/>
+        <location filename="Data.cpp" line="242"/>
         <source>Pampa</source>
         <comment>Ennemy</comment>
         <translation>Cactuar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="230"/>
+        <location filename="Data.cpp" line="243"/>
         <source>Tomberry</source>
         <comment>Ennemy</comment>
         <translation>Tonberry</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="230"/>
+        <location filename="Data.cpp" line="243"/>
         <source>Marsupial</source>
         <comment>Ennemy</comment>
         <translation>Torama</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="230"/>
+        <location filename="Data.cpp" line="243"/>
         <source>Fungus</source>
         <comment>Ennemy</comment>
         <translation>Funguar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="230"/>
+        <location filename="Data.cpp" line="243"/>
         <source>Draconus</source>
         <comment>Ennemy</comment>
         <translation>Imp</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="231"/>
+        <location filename="Data.cpp" line="244"/>
         <source>Koyo K</source>
         <comment>Ennemy</comment>
         <translation>PuPu</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="231"/>
+        <location filename="Data.cpp" line="244"/>
         <source>Ifrit</source>
         <comment>Ennemy</comment>
         <translation>Ifrit</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="231"/>
+        <location filename="Data.cpp" line="244"/>
         <source>Taurux</source>
         <comment>Ennemy</comment>
         <translation>Minotaur</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="231"/>
+        <location filename="Data.cpp" line="244"/>
         <source>Tauros</source>
         <comment>Ennemy</comment>
         <translation>Sacred</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="232"/>
+        <location filename="Data.cpp" line="245"/>
         <source>Commandeur</source>
         <comment>Ennemy</comment>
         <translation>Base Leader</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="232"/>
+        <location filename="Data.cpp" line="245"/>
         <source>Cerbères</source>
         <comment>Ennemy</comment>
         <translation>Cerberus</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="232"/>
+        <location filename="Data.cpp" line="245"/>
         <source>Nosferatu</source>
         <comment>Ennemy</comment>
         <translation>Diablos</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="232"/>
+        <location filename="Data.cpp" line="245"/>
         <source>Bahamut</source>
         <comment>Ennemy</comment>
         <translation>Bahamut</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="233"/>
+        <location filename="Data.cpp" line="246"/>
         <source>Odyssey</source>
         <comment>Ennemy</comment>
         <translation>NORG Pod</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="233"/>
+        <location filename="Data.cpp" line="246"/>
         <source>Templier</source>
         <comment>Ennemy</comment>
         <translation>Garden Faculty</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="233"/>
+        <location filename="Data.cpp" line="246"/>
         <source>Odin</source>
         <comment>Ennemy</comment>
         <translation>Odin</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="233"/>
+        <location filename="Data.cpp" line="246"/>
         <source>Galbadien</source>
         <comment>Ennemy</comment>
         <translation>G-Soldier</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="234"/>
+        <location filename="Data.cpp" line="247"/>
         <source>Elite-T</source>
         <comment>Ennemy</comment>
         <translation>Elite Soldier</translation>
@@ -7262,559 +7382,565 @@ By default Hyne attempts to automatically sign saves, but in case of error, you 
         <translation type="obsolete">Biggs</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="234"/>
+        <location filename="Data.cpp" line="247"/>
         <source>Doublure</source>
         <comment>Ennemy</comment>
         <translation>Fake President</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="235"/>
+        <location filename="Data.cpp" line="248"/>
         <source>Trooper</source>
         <comment>Ennemy</comment>
         <translation>Guard</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="235"/>
+        <location filename="Data.cpp" line="248"/>
         <source>Norg</source>
         <comment>Ennemy</comment>
         <translation>NORG</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="235"/>
+        <location filename="Data.cpp" line="248"/>
         <source>S-Borg</source>
         <comment>Ennemy</comment>
         <translation>Esthar Soldier</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="235"/>
+        <location filename="Data.cpp" line="248"/>
         <source>T-Borg</source>
         <comment>Ennemy</comment>
         <translation>Esthar Soldier</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="236"/>
+        <location filename="Data.cpp" line="249"/>
         <source>Tupolev</source>
         <comment>Ennemy</comment>
         <translation>Right Orb</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="236"/>
+        <location filename="Data.cpp" line="249"/>
         <source>Spootnik</source>
         <comment>Ennemy</comment>
         <translation>Left Orb</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="237"/>
+        <location filename="Data.cpp" line="250"/>
         <source>Seifer (1)</source>
         <comment>Ennemy</comment>
         <translation>Seifer (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="237"/>
+        <location filename="Data.cpp" line="250"/>
         <source>Seifer (2)</source>
         <comment>Ennemy</comment>
         <translation>Seifer (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="237"/>
+        <location filename="Data.cpp" line="250"/>
         <source>Seifer (3)</source>
         <comment>Ennemy</comment>
         <translation>Seifer (3)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="236"/>
+        <location filename="Data.cpp" line="249"/>
         <source>Tomberry Sr</source>
         <comment>Ennemy</comment>
         <translation>Tonberry King</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="234"/>
+        <location filename="Data.cpp" line="247"/>
         <source>Wedge (1)</source>
         <comment>Ennemy</comment>
         <translation>Wedge (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="234"/>
+        <location filename="Data.cpp" line="247"/>
         <source>Biggs (1)</source>
         <comment>Ennemy</comment>
         <translation>Biggs (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="236"/>
+        <location filename="Data.cpp" line="249"/>
         <source>Gunblade (1)</source>
         <comment>Ennemy</comment>
         <translation>Gunblade (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="237"/>
+        <location filename="Data.cpp" line="250"/>
         <source>Pampa Senior</source>
         <comment>Ennemy</comment>
         <translation>Jumbo Cactuar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="238"/>
+        <location filename="Data.cpp" line="251"/>
         <source>Edea (1)</source>
         <oldsource>Edea</oldsource>
         <comment>Ennemy</comment>
         <translation>Edea (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="238"/>
+        <location filename="Data.cpp" line="251"/>
         <source>Monarch</source>
         <comment>Ennemy</comment>
         <translation>Ultima Weapon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="238"/>
+        <location filename="Data.cpp" line="251"/>
         <source>Sulfura</source>
         <comment>Ennemy</comment>
         <translation>Elvoret</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="238"/>
+        <location filename="Data.cpp" line="251"/>
         <source>Alienator (violet)</source>
         <comment>Ennemy</comment>
         <translation>Propagator (purple)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="239"/>
+        <location filename="Data.cpp" line="252"/>
         <source>Goliath</source>
         <comment>Ennemy</comment>
         <translation>X-ATM092</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="239"/>
+        <location filename="Data.cpp" line="252"/>
         <source>Iguanor</source>
         <comment>Ennemy</comment>
         <translation>Iguion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="239"/>
+        <location filename="Data.cpp" line="252"/>
         <source>Agamemnon</source>
         <comment>Ennemy</comment>
         <translation>Gargantua</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="239"/>
+        <location filename="Data.cpp" line="252"/>
         <source>Lygus</source>
         <comment>Ennemy</comment>
         <translation>Granaldo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="240"/>
+        <location filename="Data.cpp" line="253"/>
         <source>Cujo</source>
         <comment>Ennemy</comment>
         <translation>Raldo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="240"/>
+        <location filename="Data.cpp" line="253"/>
         <source>Cyanide</source>
         <comment>Ennemy</comment>
         <translation>Oilboyle</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="240"/>
+        <location filename="Data.cpp" line="253"/>
         <source>Alienator (vert)</source>
         <comment>Ennemy</comment>
         <translation>Propagator (green)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="240"/>
+        <location filename="Data.cpp" line="253"/>
         <source>Alienator (jaune)</source>
         <comment>Ennemy</comment>
         <translation>Propagator (yellow)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="241"/>
+        <location filename="Data.cpp" line="254"/>
         <source>Hornet</source>
         <comment>Ennemy</comment>
         <translation>Abadon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="241"/>
+        <location filename="Data.cpp" line="254"/>
         <source>Edea (2)</source>
         <comment>Ennemy</comment>
         <translation>Edea (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="241"/>
+        <location filename="Data.cpp" line="254"/>
         <source>Omniborg (1)</source>
         <comment>Ennemy</comment>
         <translation>BGH251F2 (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="241"/>
+        <location filename="Data.cpp" line="254"/>
         <source>Omniborg (2)</source>
         <comment>Ennemy</comment>
         <translation>BGH251F2 (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="242"/>
+        <location filename="Data.cpp" line="255"/>
         <source>Anakronox</source>
         <comment>Ennemy</comment>
         <translation>Mobile Type 8</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="242"/>
+        <location filename="Data.cpp" line="255"/>
         <source>A-G Pod</source>
         <comment>Ennemy</comment>
         <translation>Left Probe</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="242"/>
+        <location filename="Data.cpp" line="255"/>
         <source>A-D Pod</source>
         <comment>Ennemy</comment>
         <translation>Right Probe</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="242"/>
+        <location filename="Data.cpp" line="255"/>
         <source>Hornet (zombie)</source>
         <comment>Ennemy</comment>
         <translation>Abadon (zombie)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="243"/>
+        <location filename="Data.cpp" line="256"/>
         <source>ParaBorg</source>
         <comment>Ennemy</comment>
         <translation>Paratrooper</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="243"/>
+        <location filename="Data.cpp" line="256"/>
         <source>Flotix</source>
         <comment>Ennemy</comment>
         <translation>Trauma</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="243"/>
+        <location filename="Data.cpp" line="256"/>
         <source>Bibendum</source>
         <comment>Ennemy</comment>
         <translation>Droma</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="243"/>
+        <location filename="Data.cpp" line="256"/>
         <source>Alienator (rouge)</source>
         <comment>Ennemy</comment>
         <translation>Propagator (red)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="244"/>
+        <location filename="Data.cpp" line="257"/>
         <source>Adel</source>
         <comment>Ennemy</comment>
         <translation>Adel</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="244"/>
+        <location filename="Data.cpp" line="257"/>
         <source>Nécromancienne (1)</source>
         <comment>Ennemy</comment>
         <translation>Sorceress</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="245"/>
+        <location filename="Data.cpp" line="258"/>
         <source>Fujin (1)</source>
         <comment>Ennemy</comment>
         <translation>Fujin (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="245"/>
+        <location filename="Data.cpp" line="258"/>
         <source>Nécromancienne (2)</source>
         <comment>Ennemy</comment>
         <translation>Sorceress (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="245"/>
+        <location filename="Data.cpp" line="258"/>
         <source>Nécromancienne (3)</source>
         <comment>Ennemy</comment>
         <translation>Sorceress (3)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="246"/>
+        <location filename="Data.cpp" line="259"/>
         <source>Raijin (1)</source>
         <comment>Ennemy</comment>
         <translation>Raijin (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="246"/>
+        <location filename="Data.cpp" line="259"/>
         <source>(Sans nom)</source>
         <comment>Ennemy</comment>
         <translation>(No name)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="246"/>
+        <location filename="Data.cpp" line="259"/>
         <source>Ultimecia (1)</source>
         <comment>Ennemy</comment>
         <translation>Ultimecia (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="246"/>
+        <location filename="Data.cpp" line="259"/>
         <source>Ultimecia (2)</source>
         <comment>Ennemy</comment>
         <translation>Ultimecia (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="247"/>
+        <location filename="Data.cpp" line="260"/>
         <source>Seifer (4)</source>
         <comment>Ennemy</comment>
         <translation>Seifer (4)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="247"/>
+        <location filename="Data.cpp" line="260"/>
         <source>Ultimecia (3)</source>
         <comment>Ennemy</comment>
         <translation>Ultimecia (3)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="247"/>
+        <location filename="Data.cpp" line="260"/>
         <source>Ultimecia (4)</source>
         <comment>Ennemy</comment>
         <translation>Ultimecia (4)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="249"/>
+        <location filename="Data.cpp" line="262"/>
         <source>Fujin (2)</source>
         <comment>Ennemy</comment>
         <translation>Fujin (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="249"/>
+        <location filename="Data.cpp" line="262"/>
         <source>Raijin (2)</source>
         <comment>Ennemy</comment>
         <translation>Raijin (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="249"/>
+        <location filename="Data.cpp" line="262"/>
         <source>Biggs (2)</source>
         <comment>Ennemy</comment>
         <translation>Biggs (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="250"/>
+        <location filename="Data.cpp" line="262"/>
+        <source>Wedge (2)</source>
+        <comment>Ennemy</comment>
+        <translation>Wedge (2)</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="263"/>
         <source>UFO (Mandy Beach)</source>
         <comment>Ennemy</comment>
         <translation>UFO (Mandy Beach)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="250"/>
+        <location filename="Data.cpp" line="263"/>
         <source>UFO (Winhill)</source>
         <comment>Ennemy</comment>
         <translation>UFO (Winhill)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="250"/>
+        <location filename="Data.cpp" line="263"/>
         <source>UFO (Trabia)</source>
         <comment>Ennemy</comment>
         <translation>UFO (Trabia)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="250"/>
+        <location filename="Data.cpp" line="263"/>
         <source>UFO (Désert Kashkabald)</source>
         <comment>Ennemy</comment>
         <translation>UFO (Kashkabald Desert)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="251"/>
+        <location filename="Data.cpp" line="264"/>
         <source>Gunblade (2)</source>
         <oldsource>Gunblade 2</oldsource>
         <comment>Ennemy</comment>
         <translation>Gunblade (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="811"/>
+        <location filename="Data.cpp" line="825"/>
         <source>Utilisée</source>
         <translation>Used Up</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="816"/>
+        <location filename="Data.cpp" line="830"/>
         <source> (carte %1)</source>
         <translation> (card %1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="244"/>
+        <location filename="Data.cpp" line="257"/>
         <source>Minotaure</source>
         <comment>Ennemy</comment>
         <translation>Omega Weapon</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="245"/>
+        <location filename="Data.cpp" line="258"/>
         <source>UFO</source>
         <comment>Ennemy</comment>
         <translation>UFO?</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="247"/>
+        <location filename="Data.cpp" line="260"/>
         <source>Hélix</source>
         <comment>Ennemy</comment>
         <translation>Helix</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="247"/>
+        <location filename="Data.cpp" line="260"/>
         <source>Jason</source>
         <comment>Ennemy</comment>
         <translation>Slapper</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="248"/>
+        <location filename="Data.cpp" line="261"/>
         <source>Attila</source>
         <comment>Ennemy</comment>
         <translation>Red Giant</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="248"/>
+        <location filename="Data.cpp" line="261"/>
         <source>Sulfor</source>
         <comment>Ennemy</comment>
         <translation>Elnoyle</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="248"/>
+        <location filename="Data.cpp" line="261"/>
         <source>Acarnan</source>
         <comment>Ennemy</comment>
         <translation>Tiamat</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="248"/>
+        <location filename="Data.cpp" line="261"/>
         <source>Fabryce</source>
         <comment>Ennemy</comment>
         <translation>Catoblepas</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="251"/>
+        <location filename="Data.cpp" line="264"/>
         <source>Soldat</source>
         <comment>Ennemy</comment>
         <translation>Base Soldier</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="85"/>
+        <location filename="Data.cpp" line="86"/>
         <source>Golgotha</source>
         <comment>item</comment>
         <translation>Phoenix Pinion</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="159"/>
+        <location filename="Data.cpp" line="172"/>
         <source>Shiva</source>
         <comment>gf</comment>
         <translation>Shiva</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="159"/>
+        <location filename="Data.cpp" line="172"/>
         <source>Ifrit</source>
         <comment>gf</comment>
         <translation>Ifrit</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="159"/>
+        <location filename="Data.cpp" line="172"/>
         <source>Ondine</source>
         <comment>gf</comment>
         <translation>Siren</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="160"/>
+        <location filename="Data.cpp" line="173"/>
         <source>Taurus</source>
         <comment>gf</comment>
         <translation>Brothers</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="160"/>
+        <location filename="Data.cpp" line="173"/>
         <source>Nosferatu</source>
         <comment>gf</comment>
         <translation>Diablos</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="160"/>
+        <location filename="Data.cpp" line="173"/>
         <source>Ahuri</source>
         <comment>gf</comment>
         <translation>Carbuncle</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="160"/>
+        <location filename="Data.cpp" line="173"/>
         <source>Leviathan</source>
         <comment>gf</comment>
         <translation>Leviathan</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="161"/>
+        <location filename="Data.cpp" line="174"/>
         <source>Zéphyr</source>
         <comment>gf</comment>
         <translation>Pandemona</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="161"/>
+        <location filename="Data.cpp" line="174"/>
         <source>Cerberus</source>
         <comment>gf</comment>
         <translation>Cerberus</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="161"/>
+        <location filename="Data.cpp" line="174"/>
         <source>Alexander</source>
         <comment>gf</comment>
         <translation>Alexander</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="161"/>
+        <location filename="Data.cpp" line="174"/>
         <source>Helltrain</source>
         <comment>gf</comment>
         <translation>Doomtrain</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="162"/>
+        <location filename="Data.cpp" line="175"/>
         <source>Bahamut</source>
         <comment>gf</comment>
         <translation>Bahamut</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="162"/>
+        <location filename="Data.cpp" line="175"/>
         <source>Pampa</source>
         <comment>gf</comment>
         <translation>Cactuar</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="162"/>
+        <location filename="Data.cpp" line="175"/>
         <source>Tomberry</source>
         <comment>gf</comment>
         <translation>Tonberry</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="162"/>
+        <location filename="Data.cpp" line="175"/>
         <source>Orbital</source>
         <comment>gf</comment>
         <translation>Eden</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="206"/>
+        <location filename="Data.cpp" line="219"/>
         <source>Grochocobo</source>
         <comment>card</comment>
         <translation>Chubby Chocobo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="206"/>
+        <location filename="Data.cpp" line="219"/>
         <source>Angel</source>
         <comment>card</comment>
         <translation>Angelo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="206"/>
+        <location filename="Data.cpp" line="219"/>
         <source>Gilgamesh</source>
         <comment>card</comment>
         <translation>Gilgamesh</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="206"/>
+        <location filename="Data.cpp" line="219"/>
         <source>Minimog</source>
         <comment>card</comment>
         <translation>MiniMog</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="206"/>
+        <location filename="Data.cpp" line="219"/>
         <source>Chicobo</source>
         <comment>card</comment>
         <translation>Chicobo</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="207"/>
+        <location filename="Data.cpp" line="220"/>
         <source>Golgotha</source>
         <comment>card</comment>
         <translation>Quezacotl</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="208"/>
+        <location filename="Data.cpp" line="221"/>
         <source>Cerbères</source>
         <translation>Cerberus</translation>
     </message>
@@ -7825,75 +7951,81 @@ By default Hyne attempts to automatically sign saves, but in case of error, you 
         <translation>false</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="168"/>
+        <location filename="SavecardData.cpp" line="170"/>
         <source>Sans nom</source>
         <translation>Unnamed</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="222"/>
-        <location filename="SavecardData.cpp" line="276"/>
-        <location filename="SavecardData.cpp" line="530"/>
+        <location filename="SavecardData.cpp" line="224"/>
+        <location filename="SavecardData.cpp" line="280"/>
+        <location filename="SavecardData.cpp" line="559"/>
         <source>Le fichier n&apos;existe plus.
 %1</source>
         <translation>The file no longer exists.
 %1</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="227"/>
-        <location filename="SavecardData.cpp" line="281"/>
-        <location filename="SavecardData.cpp" line="418"/>
+        <location filename="SavecardData.cpp" line="229"/>
+        <location filename="SavecardData.cpp" line="285"/>
+        <location filename="SavecardData.cpp" line="447"/>
         <source>Le fichier est protégé en lecture.</source>
         <translation>The file is read-protected.</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="232"/>
+        <location filename="SavecardData.cpp" line="234"/>
         <source>Fichier trop court</source>
         <translation>File too short</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="292"/>
+        <location filename="SavecardData.cpp" line="296"/>
         <source>Fichier invalide</source>
         <translation>Invalid file</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="394"/>
+        <location filename="SavecardData.cpp" line="423"/>
         <source>Impossible de créer le fichier temporaire.</source>
         <translation>Unable to create the temporary file.</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="398"/>
+        <location filename="SavecardData.cpp" line="427"/>
         <source>Impossible de décompresser le fichier.</source>
         <translation>Unable to uncompress the file.</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="452"/>
+        <location filename="SavecardData.cpp" line="481"/>
         <source>Format invalide.</source>
         <translation>Invalid format.</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="463"/>
+        <location filename="SavecardData.cpp" line="492"/>
         <source>La sauvegarde trouvée n&apos;est pas de Final Fantasy VIII.</source>
         <translation>The found save is not from Final Fantasy VIII.</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="535"/>
+        <location filename="SavecardData.cpp" line="564"/>
         <source>Le fichier est protégé en lecture.
 %1</source>
         <translation>The file is read-protected.
 %1</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="541"/>
-        <location filename="SavecardData.cpp" line="633"/>
-        <location filename="SavecardData.cpp" line="726"/>
-        <location filename="SavecardData.cpp" line="781"/>
+        <location filename="SavecardData.cpp" line="570"/>
+        <location filename="SavecardData.cpp" line="673"/>
+        <location filename="SavecardData.cpp" line="778"/>
+        <location filename="SavecardData.cpp" line="839"/>
         <source>Impossible de créer un fichier temporaire</source>
         <translation>Cannot create temporary file</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="606"/>
-        <location filename="SavecardData.cpp" line="755"/>
-        <location filename="SavecardData.cpp" line="835"/>
+        <location filename="SavecardData.cpp" line="624"/>
+        <source>Type non supporté pour la sauvegarde.
+%1</source>
+        <translation>Unsupported type %1</translation>
+    </message>
+    <message>
+        <location filename="SavecardData.cpp" line="642"/>
+        <location filename="SavecardData.cpp" line="809"/>
+        <location filename="SavecardData.cpp" line="895"/>
         <source>Impossible de supprimer le fichier !
 %1
 Échec de la sauvegarde.
@@ -7904,42 +8036,42 @@ Failed to save.
 Verify that the file is not used by another program.</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="612"/>
-        <location filename="SavecardData.cpp" line="703"/>
-        <location filename="SavecardData.cpp" line="761"/>
-        <location filename="SavecardData.cpp" line="844"/>
+        <location filename="SavecardData.cpp" line="650"/>
+        <location filename="SavecardData.cpp" line="753"/>
+        <location filename="SavecardData.cpp" line="817"/>
+        <location filename="SavecardData.cpp" line="906"/>
         <source>Échec de la sauvegarde.</source>
         <translation>Save failed.</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="625"/>
+        <location filename="SavecardData.cpp" line="665"/>
         <source>Cette sauvegarde ne provient pas de Final Fantasy VIII.</source>
         <translation>This save is not from Final Fantasy VIII.</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="659"/>
+        <location filename="SavecardData.cpp" line="701"/>
         <source>Le fichier &apos;metadata.xml&apos; n&apos;a pas été trouvé dans le dossier &apos;%1&apos;.
 Essayez de signer vos sauvegardes manuellement (Fichier &gt; Signer les sauv. pour le Cloud).</source>
         <translation>The &apos;metadata.xml&apos; file was not found in the directory &apos;%1&apos;.
 Try to sign your saves manually (File &gt; Sign saves for the Cloud).</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="662"/>
+        <location filename="SavecardData.cpp" line="704"/>
         <source>Le fichier &apos;metadata.xml&apos; n&apos;a pas pu être ouvert.
 %1</source>
         <translation>The &apos;metadata.xml&apos; file cannot be opened.
 %1</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="673"/>
-        <location filename="SavecardData.cpp" line="688"/>
+        <location filename="SavecardData.cpp" line="715"/>
+        <location filename="SavecardData.cpp" line="736"/>
         <source>Le fichier &apos;metadata.xml&apos; n&apos;a pas pu être mis à jour.
 %1</source>
         <translation>The &apos;metadata.xml&apos; file cannot be updated.
 %1</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="696"/>
+        <location filename="SavecardData.cpp" line="744"/>
         <source>Impossible de supprimer le fichier !
 %1
 Échec de la sauvegarde.
@@ -7962,17 +8094,17 @@ Try to launch %2 as admin.</translation>
         <translation type="obsolete">Cannot load file contents &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="FF8Installation.cpp" line="97"/>
+        <location filename="FF8Installation.cpp" line="110"/>
         <source>FF8 Standard</source>
         <translation>FF8 Standard</translation>
     </message>
     <message>
-        <location filename="FF8Installation.cpp" line="99"/>
+        <location filename="FF8Installation.cpp" line="112"/>
         <source>FF8 Steam</source>
         <translation>FF8 Steam</translation>
     </message>
     <message>
-        <location filename="FF8Installation.cpp" line="101"/>
+        <location filename="FF8Installation.cpp" line="114"/>
         <source>FF8 personnalisé</source>
         <oldsource>FF8 personnalisÃ©</oldsource>
         <translation>FF8 custom</translation>
@@ -8208,39 +8340,39 @@ Would you analyze it to get the right format?</translation>
 <context>
     <name>SavecardView</name>
     <message>
-        <location filename="SavecardView.cpp" line="74"/>
+        <location filename="SavecardView.cpp" line="76"/>
         <source>Fichier supprimé</source>
         <translation>File removed</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="75"/>
+        <location filename="SavecardView.cpp" line="77"/>
         <source>Le fichier &apos;%1&apos; a été supprimé par un programme externe !</source>
         <translation>The file &apos;%1&apos; has been removed by another program!</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="79"/>
+        <location filename="SavecardView.cpp" line="81"/>
         <source>Fichier modifié</source>
         <translation>File modified</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="80"/>
+        <location filename="SavecardView.cpp" line="82"/>
         <source>Le fichier &apos;%1&apos; a été modifié par un programme externe.</source>
         <translation>The file &apos;%1&apos; has been modified by another program.</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="203"/>
+        <location filename="SavecardView.cpp" line="205"/>
         <source>Écraser</source>
         <translation>Overwrite</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="203"/>
+        <location filename="SavecardView.cpp" line="205"/>
         <source>Tout le contenu de la sauvegarde sera écrasé.
 Continuer ?</source>
         <translation>All content of the save will be overwritten.
 Continue?</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="268"/>
+        <location filename="SavecardView.cpp" line="270"/>
         <source>Exporter</source>
         <translation>Export</translation>
     </message>
@@ -8249,51 +8381,51 @@ Continue?</translation>
         <translation type="obsolete">FF8 PC save (*)</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="268"/>
+        <location filename="SavecardView.cpp" line="270"/>
         <source>FF8 PC save (* *.ff8)</source>
         <translation>FF8 PC save (* *.ff8)</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="275"/>
+        <location filename="SavecardView.cpp" line="277"/>
         <source>Échec</source>
         <translation>Failed</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="275"/>
+        <location filename="SavecardView.cpp" line="277"/>
         <source>Enregistrement échoué, vérifiez que le fichier cible n&apos;est pas utilisé.</source>
         <translation>Save failed, verify that the target file is not used.</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="291"/>
+        <location filename="SavecardView.cpp" line="293"/>
         <source>Nouvelle partie</source>
         <translation>New game</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="291"/>
+        <location filename="SavecardView.cpp" line="293"/>
         <source>Tout le contenu de la sauvegarde sera remplacé par une nouvelle partie.
 Continuer ?</source>
         <translation>All content of the save will be replaced with a new game.
 Continue?</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="345"/>
+        <location filename="SavecardView.cpp" line="347"/>
         <source>Vider</source>
         <translation>Empty</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="345"/>
+        <location filename="SavecardView.cpp" line="347"/>
         <source>Tout le contenu de la sauvegarde sera vidé.
 Continuer ?</source>
         <translation>All content of the save will be emptied.
 Continue?</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="385"/>
+        <location filename="SavecardView.cpp" line="387"/>
         <source>Sauvegarde supprimée</source>
         <translation>Save deleted</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="385"/>
+        <location filename="SavecardView.cpp" line="387"/>
         <source>Cette sauvegarde a été supprimée, voulez-vous tenter de la réparer ? (succès non garanti)</source>
         <translation>This save has been deleted, do you try to repair it? (Success not guaranteed)</translation>
     </message>
@@ -8306,42 +8438,42 @@ Continue?</translation>
         <translation type="obsolete">No</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="496"/>
+        <location filename="SavecardView.cpp" line="498"/>
         <source>NV%1</source>
         <translation>LV%1</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="544"/>
+        <location filename="SavecardView.cpp" line="546"/>
         <source>Bloc occupé</source>
         <translation>Used block</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="549"/>
+        <location filename="SavecardView.cpp" line="551"/>
         <source>Bloc Disponible</source>
         <translation>unused block</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="831"/>
+        <location filename="SavecardView.cpp" line="833"/>
         <source>&amp;Modifier...</source>
         <translation>&amp;Edit...</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="832"/>
+        <location filename="SavecardView.cpp" line="834"/>
         <source>&amp;Exporter en sauv. PC...</source>
         <translation>&amp;Convert to PC Save...</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="834"/>
+        <location filename="SavecardView.cpp" line="836"/>
         <source>&amp;Nouvelle partie</source>
         <translation>&amp;New game</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="836"/>
+        <location filename="SavecardView.cpp" line="838"/>
         <source>&amp;Vider</source>
         <translation>E&amp;mpty</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="838"/>
+        <location filename="SavecardView.cpp" line="840"/>
         <source>&amp;Propriétés...</source>
         <translation>&amp;Properties...</translation>
     </message>
@@ -8527,7 +8659,6 @@ Continue?</translation>
         <translation>Cards</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="40"/>
         <location filename="PageWidgets/TTriadEditor.cpp" line="253"/>
         <source>Règles</source>
         <translation>Rules</translation>
@@ -8575,19 +8706,16 @@ Continue?</translation>
     </message>
     <message>
         <location filename="PageWidgets/TTriadEditor.cpp" line="239"/>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
         <source>Dollet</source>
         <translation>Dollet</translation>
     </message>
     <message>
         <location filename="PageWidgets/TTriadEditor.cpp" line="240"/>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
         <source>Horizon</source>
         <translation>F. Horizon</translation>
     </message>
     <message>
         <location filename="PageWidgets/TTriadEditor.cpp" line="240"/>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
         <source>Lunar Gate</source>
         <translation>Lunar Gate</translation>
     </message>
@@ -8673,108 +8801,183 @@ Continue?</translation>
     </message>
     <message>
         <location filename="PageWidgets/TTriadEditor.cpp" line="269"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="281"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="325"/>
         <source>Aucune</source>
         <translation>None</translation>
     </message>
     <message>
         <location filename="PageWidgets/TTriadEditor.cpp" line="278"/>
+        <source>Quêtes</source>
+        <translation>Quests</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="294"/>
+        <source>-</source>
+        <translation>-</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="294"/>
+        <source>Valet</source>
+        <translation>Jack</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="294"/>
+        <source>Trèfle</source>
+        <translation>Clover</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="294"/>
+        <source>Carreaux</source>
+        <translation>Diamonds</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="294"/>
+        <source>Pique</source>
+        <translation>Spade</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="294"/>
+        <source>Reine de coeur</source>
+        <translation>Queen of heart</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="304"/>
+        <source>Nulle part</source>
+        <translation>Nowhere</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="326"/>
+        <source>Kiros</source>
+        <translation>Kiros</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="327"/>
+        <source>Irvine</source>
+        <translation>Irvine</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="328"/>
+        <source>GroChocobo</source>
+        <translation>Chubby Chocobo</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="330"/>
+        <source>Phénix</source>
+        <translation>Phoenix</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="335"/>
+        <source>Quête du Groupe CC :</source>
+        <translation>CC Group quest:</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="339"/>
+        <source>Règle du vainqueur de la reine :</source>
+        <translation>Trade rule of the queen:</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="343"/>
+        <source>Région règle du vainqueur :</source>
+        <translation>Trade rule location:</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="347"/>
+        <source>Dernière carte créée :</source>
+        <translation>Last created card:</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="350"/>
         <source>Divers</source>
         <translation>Miscellaneous</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="369"/>
+        <source>Nombre de victoires à la BGU :</source>
+        <translation>BGU Victory Count:</translation>
+    </message>
+    <message>
         <source>Balamb City</source>
-        <translation>Balamb City</translation>
+        <translation type="vanished">Balamb City</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
         <source>Deling City</source>
-        <translation>Deling City</translation>
+        <translation type="vanished">Deling City</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
         <source>Shumi village</source>
-        <translation>Shumi village</translation>
+        <translation type="vanished">Shumi village</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
         <source>Winhill</source>
-        <translation>Winhill</translation>
+        <translation type="vanished">Winhill</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
         <source>Esthar City</source>
-        <translation>Esthar City</translation>
+        <translation type="vanished">Esthar City</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="315"/>
         <source>MiniMog</source>
-        <translation>MiniMog</translation>
+        <translation type="vanished">MiniMog</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="316"/>
         <source>Tauros</source>
-        <translation>Sacred</translation>
+        <translation type="vanished">Sacred</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="317"/>
         <source>Chicobo</source>
-        <translation>Chicobo</translation>
+        <translation type="vanished">Chicobo</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="318"/>
         <source>Alexander</source>
-        <translation>Alexander</translation>
+        <translation type="vanished">Alexander</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="319"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="329"/>
         <source>Helltrain</source>
         <translation>Doomtrain</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="320"/>
         <source>Toutes</source>
-        <translation>All</translation>
+        <translation type="vanished">All</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="322"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="358"/>
         <source>Inconnu 1 :</source>
         <translation>Unknown 1:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="324"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="360"/>
         <source>Inconnu 2 :</source>
         <translation>Unknown 2:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="327"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="332"/>
         <source>Dernières régions visitées :</source>
         <translation>Last region visited:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="332"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="341"/>
         <source>Nombre de joueurs règle du vainqueur :</source>
         <translation>Trade rating:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="336"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="345"/>
         <source>Dégénération :</source>
         <translation>Degeneration:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="338"/>
         <source>Cartes créées :</source>
-        <translation>Cards created:</translation>
+        <translation type="vanished">Cards created:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="330"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="337"/>
         <source>Emplacement reine des cartes :</source>
         <translation>Card Queen location:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="334"/>
         <source>Région :</source>
-        <translation>Region:</translation>
+        <translation type="vanished">Region:</translation>
     </message>
     <message>
         <location filename="PageWidgets/TTriadEditor.cpp" line="81"/>
@@ -8792,23 +8995,23 @@ Continue?</translation>
         <translation>Location</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="340"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="363"/>
         <source>Nombre de victoires :</source>
         <translation>Victory Count:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="342"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="365"/>
         <source>Nombre de défaites :</source>
         <translation>Defeat Count:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="344"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="367"/>
         <source>Nombre d&apos;égalités :</source>
         <translation>Egality Count:</translation>
     </message>
     <message>
         <location filename="PageWidgets/TTriadEditor.cpp" line="179"/>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="544"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="576"/>
         <source>Squall</source>
         <translation>Squall</translation>
     </message>
@@ -8851,28 +9054,28 @@ Continue?</translation>
         <translation type="obsolete">&amp;Recent Files</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="78"/>
-        <location filename="Window.cpp" line="918"/>
+        <location filename="Window.cpp" line="82"/>
+        <location filename="Window.cpp" line="934"/>
         <source>&amp;Fermer</source>
         <translation>&amp;Close</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="80"/>
+        <location filename="Window.cpp" line="84"/>
         <source>&amp;Quitter</source>
         <translation>&amp;Exit</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="85"/>
+        <location filename="Window.cpp" line="89"/>
         <source>Fente &amp;1</source>
         <translation>Slot &amp;1</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="86"/>
+        <location filename="Window.cpp" line="90"/>
         <source>Fente &amp;2</source>
         <translation>Slot &amp;2</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="91"/>
+        <location filename="Window.cpp" line="95"/>
         <source>&amp;Paramètres</source>
         <translation>&amp;Settings</translation>
     </message>
@@ -8885,14 +9088,14 @@ Continue?</translation>
         <translation type="obsolete">High Res. font</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="116"/>
+        <location filename="Window.cpp" line="120"/>
         <source>&amp;Langue</source>
         <oldsource>&amp;Langues</oldsource>
         <translation>&amp;Language</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="138"/>
-        <location filename="Window.cpp" line="140"/>
+        <location filename="Window.cpp" line="142"/>
+        <location filename="Window.cpp" line="144"/>
         <source>&amp;?</source>
         <oldsource>?</oldsource>
         <translation>&amp;?</translation>
@@ -8942,7 +9145,7 @@ Translators:
  - Japanese: Asa</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="294"/>
+        <location filename="Window.cpp" line="298"/>
         <source>Ouvrir</source>
         <translation>Open</translation>
     </message>
@@ -8955,7 +9158,7 @@ Translators:
         <translation type="obsolete">PS memorycard (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="435"/>
+        <location filename="Window.cpp" line="439"/>
         <source>VGS memorycard (*.vgs *.mem)</source>
         <oldsource>PS memorycard (*.mcr;*.ddf;*.mc;*.mcd;*.mci;*.ps;*.psm)</oldsource>
         <translation>VGS memorycard (*.vgs *.mem)</translation>
@@ -8966,28 +9169,28 @@ Translators:
         <translation type="obsolete">FF8 PC save (*)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="474"/>
+        <location filename="Window.cpp" line="481"/>
         <source>Les formats VMP et PSV sont protégés, l&apos;enregistrement sera partiel et risque de ne pas fonctionner.
 Continuer quand même ?</source>
         <translation>VMP and PSV formats are protected, save will be partial and might not work.
 Continue anyway?</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="262"/>
-        <location filename="Window.cpp" line="346"/>
-        <location filename="Window.cpp" line="356"/>
-        <location filename="Window.cpp" line="580"/>
-        <location filename="Window.cpp" line="868"/>
+        <location filename="Window.cpp" line="266"/>
+        <location filename="Window.cpp" line="350"/>
+        <location filename="Window.cpp" line="360"/>
+        <location filename="Window.cpp" line="594"/>
+        <location filename="Window.cpp" line="883"/>
         <source>Erreur</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="582"/>
+        <location filename="Window.cpp" line="596"/>
         <source>Attention</source>
         <translation>Warning</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="868"/>
+        <location filename="Window.cpp" line="883"/>
         <source>Final Fantasy VIII n&apos;a pas pu être lancé.
 %1</source>
         <translation>Final Fantasy VIII could not be launched.
@@ -9025,7 +9228,7 @@ Continue anyway?</translation>
         <translation type="vanished">English</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="221"/>
+        <location filename="Window.cpp" line="225"/>
         <source> - save %1</source>
         <translation> - save %1</translation>
     </message>
@@ -9051,17 +9254,17 @@ Continue anyway?</translation>
         <translation>S&amp;ign saves for the Cloud...</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="63"/>
+        <location filename="Window.cpp" line="64"/>
         <source>&amp;Lancer Final Fantasy VIII</source>
         <translation>&amp;Launch Final Fantasy VIII</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="70"/>
+        <location filename="Window.cpp" line="74"/>
         <source>Nou&amp;velle fenêtre</source>
         <translation>Ne&amp;w window</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="71"/>
+        <location filename="Window.cpp" line="75"/>
         <source>Ple&amp;in écran</source>
         <translation>&amp;Fullscreen</translation>
     </message>
@@ -9075,62 +9278,67 @@ Continue anyway?</translation>
         <translation type="obsolete">New window</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="93"/>
+        <location filename="Window.cpp" line="97"/>
         <source>&amp;Mode Avancé</source>
         <translation>Advanced &amp;Mode</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="97"/>
+        <location filename="Window.cpp" line="101"/>
         <source>&amp;Images par seconde</source>
         <translation>&amp;FPS</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="98"/>
+        <location filename="Window.cpp" line="102"/>
         <source>&amp;Auto</source>
         <translation>&amp;Auto</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="102"/>
+        <location filename="Window.cpp" line="106"/>
         <source>&amp;NTSC/PC (60 images/s)</source>
         <translation>&amp;NTSC/PC (60 fps)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="106"/>
+        <location filename="Window.cpp" line="110"/>
         <source>&amp;PAL (50 images/s)</source>
         <translation>&amp;PAL (50 fps)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="112"/>
+        <location filename="Window.cpp" line="116"/>
         <source>&amp;Police haute résolution</source>
         <translation>&amp;High Res. font</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="126"/>
+        <location filename="Window.cpp" line="130"/>
         <source>Version PC</source>
         <translation>PC Version</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="234"/>
+        <location filename="Window.cpp" line="238"/>
         <source>Nouveau</source>
         <translation>New</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="236"/>
+        <location filename="Window.cpp" line="240"/>
         <source>Sans nom</source>
         <translation>Unnamed</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="238"/>
+        <location filename="Window.cpp" line="242"/>
         <source>1 sauvegarde</source>
         <translation>1 save</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="239"/>
+        <location filename="Window.cpp" line="243"/>
         <source>15 sauvegardes</source>
         <translation>15 saves</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="904"/>
+        <location filename="Window.cpp" line="443"/>
+        <source>PS4 Remaster save (*.ff8 *)</source>
+        <translation>PS4 Remaster save (*.ff8 *)</translation>
+    </message>
+    <message>
+        <location filename="Window.cpp" line="920"/>
         <source>Par myst6re&lt;br/&gt;&lt;a href=&quot;https://sourceforge.net/projects/hyne/&quot;&gt;https://sourceforge.net/projects/hyne/&lt;/a&gt;&lt;br/&gt;&lt;br/&gt;75% modifiable&lt;br/&gt;&lt;br/&gt;Merci à :&lt;br/&gt; - Qhimm&lt;br/&gt; - Cyberman&lt;br/&gt; - sithlord48&lt;br/&gt; - Aladore384&lt;br/&gt; - suloku&lt;br/&gt;&lt;br/&gt;Traducteurs :&lt;br/&gt; - Anglais : myst6re, Vgr&lt;br/&gt; - Japonais : Asa, Sharleen</source>
         <translation>By myst6re&lt;br/&gt;&lt;a href=&quot;https://sourceforge.net/projects/hyne/&quot;&gt;https://sourceforge.net/projects/hyne/&lt;/a&gt;&lt;br/&gt;&lt;br/&gt;75% editable&lt;br/&gt;&lt;br/&gt;Thanks to:&lt;br/&gt; - Qhimm&lt;br/&gt; - Cyberman&lt;br/&gt; - sithlord48&lt;br/&gt; - Aladore384&lt;br/&gt; - suloku&lt;br/&gt;&lt;br/&gt;Translators:&lt;br/&gt; - English: myst6re, Vgr&lt;br/&gt; - Japanese: Asa, Sharleen</translation>
     </message>
@@ -9140,72 +9348,72 @@ Continue anyway?</translation>
         <translation type="obsolete">Compatible files (*.mcr *.ddf *.gme *.mc *.mcd *.mci *.ps *.psm *.vm1 *.psv save?? *.mem *.vgs *.vmp *.000 *.001 *.002 *.003 *.004);;FF8 PS memorycard (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm);;FF8 PC save (save??);;FF8 vgs memorycard (*.mem *.vgs);;FF8 gme memorycard (*.gme);;FF8 PSN memorycard (*.vmp);;FF8 PS3 memorycard/pSX save state (*.psv);;ePSXe save state (*.000 *.001 *.002 *.003 *.004);;All files (*)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="316"/>
+        <location filename="Window.cpp" line="320"/>
         <source>Enregistrer ?</source>
         <translation>Save?</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="317"/>
+        <location filename="Window.cpp" line="321"/>
         <source>Voulez-vous enregistrer &apos;%1&apos; avant de fermer ?</source>
         <translation>Save file &apos;%1&apos;?</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="319"/>
+        <location filename="Window.cpp" line="323"/>
         <source>fente</source>
         <translation>slot</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="346"/>
+        <location filename="Window.cpp" line="350"/>
         <source>Fichier de type inconnu.
 Voulez-vous l&apos;analyser pour obtenir le bon format ?</source>
         <translation>Unknown file type.
 Would you analyze it to get the right format?</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="366"/>
+        <location filename="Window.cpp" line="370"/>
         <source>Le format %1 est protégé, l&apos;enregistrement sera partiel et risque de ne pas fonctionner.</source>
         <translation>The format %1 is protected, save will be partial and might not work.</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="434"/>
+        <location filename="Window.cpp" line="438"/>
         <source>PS memorycard (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm *.vm1 *.srm)</source>
         <oldsource>PS memorycard (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm *.vm1)</oldsource>
         <translation>PS memorycard (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm *.vm1 *.srm)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="436"/>
+        <location filename="Window.cpp" line="440"/>
         <source>GME memorycard (*.gme)</source>
         <oldsource>VGS memorycard (*.vgs;*.mem)</oldsource>
         <translation>GME memorycard (*.gme)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="437"/>
+        <location filename="Window.cpp" line="441"/>
         <source>PSN memorycard (*.vmp)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="438"/>
+        <location filename="Window.cpp" line="442"/>
         <source>FF8 PC save (*.ff8 *)</source>
         <translation>FF8 PC save (*.ff8 *)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="439"/>
+        <location filename="Window.cpp" line="444"/>
         <source>PSN save (*.psv)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="458"/>
+        <location filename="Window.cpp" line="464"/>
         <source>Exporter</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="365"/>
-        <location filename="Window.cpp" line="473"/>
+        <location filename="Window.cpp" line="369"/>
+        <location filename="Window.cpp" line="480"/>
         <source>Sauvegarde hasardeuse</source>
         <translation>Save hazardous</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="295"/>
+        <location filename="Window.cpp" line="299"/>
         <source>Fichiers compatibles (*.mcr *.ddf *.gme *.mc *.mcd *.mci *.ps *.psm *.vm1 *.srm *.psv save?? *.ff8 *.mem *.vgs *.vmp *.000 *.001 *.002 *.003 *.004);;FF8 PS memorycard (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm *.vm1 *.srm);;FF8 PC save (save?? *.ff8);;FF8 vgs memorycard (*.mem *.vgs);;FF8 gme memorycard (*.gme);;FF8 PSN memorycard (*.vmp);;FF8 PS3 memorycard/pSX save state (*.psv);;ePSXe save state (*.000 *.001 *.002 *.003 *.004);;Tous les fichiers (*)</source>
         <oldsource>Fichiers compatibles (*.mcr *.ddf *.gme *.mc *.mcd *.mci *.ps *.psm *.vm1 *.psv save?? *.ff8 *.mem *.vgs *.vmp *.000 *.001 *.002 *.003 *.004);;FF8 PS memorycard (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm *.vm1);;FF8 PC save (save?? *.ff8);;FF8 vgs memorycard (*.mem *.vgs);;FF8 gme memorycard (*.gme);;FF8 PSN memorycard (*.vmp);;FF8 PS3 memorycard/pSX save state (*.psv);;ePSXe save state (*.000 *.001 *.002 *.003 *.004);;Tous les fichiers (*)</oldsource>
         <translation>Compatible files (*.mcr *.ddf *.gme *.mc *.mcd *.mci *.ps *.psm *.vm1 *.srm *.psv save?? *.ff8 *.mem *.vgs *.vmp *.000 *.001 *.002 *.003 *.004);;FF8 PS memorycard (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm *.vm1 *.srm);;FF8 PC save (save?? *.ff8);;FF8 vgs memorycard (*.mem *.vgs);;FF8 gme memorycard (*.gme);;FF8 PSN memorycard (*.vmp);;FF8 PS3 memorycard/pSX save state (*.psv);;ePSXe save state (*.000 *.001 *.002 *.003 *.004);;All files (*)</translation>
@@ -9219,27 +9427,27 @@ Would you analyze it to get the right format?</translation>
         <translation type="obsolete">No</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="593"/>
+        <location filename="Window.cpp" line="607"/>
         <source>Commentaire</source>
         <translation>Comment</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="662"/>
+        <location filename="Window.cpp" line="676"/>
         <source>%1 : %2</source>
         <translation>%1: %2</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="845"/>
+        <location filename="Window.cpp" line="859"/>
         <source>Paramètres modifiés</source>
         <translation>Settings changed</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="846"/>
+        <location filename="Window.cpp" line="860"/>
         <source>Relancez le programme pour que les paramètres prennent effet.</source>
         <translation>Restart the program for the settings to take effect.</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="888"/>
+        <location filename="Window.cpp" line="904"/>
         <source>À propos</source>
         <translation>About</translation>
     </message>

--- a/hyne_ja.ts
+++ b/hyne_ja.ts
@@ -2208,59 +2208,64 @@ By default Hyne attempts to automatically sign saves, but in case of error, you 
     </message>
     <message>
         <location filename="PageWidgets/PartyEditor.cpp" line="65"/>
+        <source>Position prédéfinie</source>
+        <translation type="unfinished">Presets</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/PartyEditor.cpp" line="76"/>
         <source>X :</source>
         <translation type="unfinished">X:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="66"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="77"/>
         <source>Y :</source>
         <translation type="unfinished">Y:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="67"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="78"/>
         <source>Triangle ID :</source>
         <translation type="unfinished">Triangle ID:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="68"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="79"/>
         <source>Direction :</source>
         <translation type="unfinished">方向:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="72"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="83"/>
         <source>Membre %1 :</source>
         <translation type="unfinished">メンバー %1:</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="90"/>
-        <location filename="PageWidgets/PartyEditor.cpp" line="91"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="101"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="102"/>
         <source>Terrain</source>
         <translation>フィールドマップ</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="92"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="103"/>
         <source>Mappemonde</source>
         <translation>ワールドマップ</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="93"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="104"/>
         <source>Combat</source>
         <translation>バトル</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="111"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="124"/>
         <source>Terrain courant</source>
         <translation type="unfinished">フィールド</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="113"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="126"/>
         <source>Terrain précédent</source>
         <translation type="unfinished">前フィールド</translation>
     </message>
     <message>
-        <location filename="PageWidgets/PartyEditor.cpp" line="141"/>
-        <location filename="PageWidgets/PartyEditor.cpp" line="148"/>
-        <location filename="PageWidgets/PartyEditor.cpp" line="155"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="154"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="161"/>
+        <location filename="PageWidgets/PartyEditor.cpp" line="168"/>
         <source>Inconnu (%1)</source>
         <translation>詳細不明 (%1)</translation>
     </message>
@@ -2830,2600 +2835,2600 @@ By default Hyne attempts to automatically sign saves, but in case of error, you 
 <context>
     <name>QObject</name>
     <message>
-        <location filename="Data.cpp" line="41"/>
+        <location filename="Data.cpp" line="42"/>
         <source>Vgr-A</source>
         <translatorcomment>Str-J</translatorcomment>
         <translation>力J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="41"/>
+        <location filename="Data.cpp" line="42"/>
         <source>Dfs-A</source>
         <translatorcomment>Vit-J</translatorcomment>
         <translation>体力J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="41"/>
+        <location filename="Data.cpp" line="42"/>
         <source>Mgi-A</source>
         <translatorcomment>Mag-J</translatorcomment>
         <translation>魔力J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="41"/>
+        <location filename="Data.cpp" line="42"/>
         <source>Psy-A</source>
         <translatorcomment>Spr-J</translatorcomment>
         <translation>精神J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="41"/>
+        <location filename="Data.cpp" line="42"/>
         <source>HP-A</source>
         <translatorcomment>HP-J</translatorcomment>
         <translation>HPJ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="42"/>
+        <location filename="Data.cpp" line="43"/>
         <source>Vts-A</source>
         <translatorcomment>Spd-J</translatorcomment>
         <translation>早さJ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="42"/>
+        <location filename="Data.cpp" line="43"/>
         <source>Esq-A</source>
         <translatorcomment>Eva-J</translatorcomment>
         <translation>回避J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="42"/>
+        <location filename="Data.cpp" line="43"/>
         <source>Prc-A</source>
         <translatorcomment>Hit-J</translatorcomment>
         <translation>命中J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="42"/>
+        <location filename="Data.cpp" line="43"/>
         <source>Chc-A</source>
         <translatorcomment>Luck-J</translatorcomment>
         <translation>運J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="42"/>
+        <location filename="Data.cpp" line="43"/>
         <source>Atq-Élé-A</source>
         <translatorcomment>Elem-Atk-J</translatorcomment>
         <translation>属性攻撃J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="43"/>
+        <location filename="Data.cpp" line="44"/>
         <source>Atq-Mtl-A</source>
         <translatorcomment>ST-Atk-J</translatorcomment>
         <translation>ST攻撃J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="43"/>
+        <location filename="Data.cpp" line="44"/>
         <source>Déf-Élé-A</source>
         <translatorcomment>Elem-Def-J</translatorcomment>
         <translation>属性防御J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="43"/>
+        <location filename="Data.cpp" line="44"/>
         <source>Déf-Mtl-A</source>
         <translatorcomment>ST-Def-J</translatorcomment>
         <translation>ST防御J</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="43"/>
+        <location filename="Data.cpp" line="44"/>
         <source>Déf-ÉléX2</source>
         <translatorcomment>Elem-Defx2</translatorcomment>
         <translation>属性防御Jx2</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="43"/>
+        <location filename="Data.cpp" line="44"/>
         <source>Déf-ÉléX4</source>
         <translatorcomment>Elem-Defx4</translatorcomment>
         <translation>属性防御Jx4</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="44"/>
+        <location filename="Data.cpp" line="45"/>
         <source>Déf-Mtl-Ax2</source>
         <translatorcomment>ST-Def-Jx2</translatorcomment>
         <translation>ST防御Jx2</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="44"/>
+        <location filename="Data.cpp" line="45"/>
         <source>Déf-Mtl-Ax4</source>
         <translatorcomment>ST-Def-Jx4</translatorcomment>
         <translation>ST防御Jx4</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="44"/>
+        <location filename="Data.cpp" line="45"/>
         <source>CapacitéX3</source>
         <translatorcomment>Abilityx3</translatorcomment>
         <translation>アビリティx3</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="44"/>
+        <location filename="Data.cpp" line="45"/>
         <source>CapacitéX4</source>
         <translatorcomment>Abilityx4</translatorcomment>
         <translation>アビリティx4</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="44"/>
+        <location filename="Data.cpp" line="45"/>
         <source>Magie</source>
         <translatorcomment>Magic</translatorcomment>
         <translation>まほう</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="45"/>
+        <location filename="Data.cpp" line="46"/>
         <source>G-Force</source>
         <translatorcomment>GF</translatorcomment>
         <translation>Ｇ．Ｆ．</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="45"/>
+        <location filename="Data.cpp" line="46"/>
         <source>Voler</source>
         <translatorcomment>Draw</translatorcomment>
         <translation>ドロー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="45"/>
+        <location filename="Data.cpp" line="46"/>
         <source>Objets</source>
         <translatorcomment>Item</translatorcomment>
         <translation>アイテム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="45"/>
+        <location filename="Data.cpp" line="46"/>
         <source>Carte</source>
         <translatorcomment>Card</translatorcomment>
         <translation>カード</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="46"/>
+        <location filename="Data.cpp" line="47"/>
         <source>Châtiment</source>
         <translatorcomment>Doom</translatorcomment>
         <translation>しのせんこく</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="46"/>
+        <location filename="Data.cpp" line="47"/>
         <source>Mad Rush</source>
         <translatorcomment>Mad Rush</translatorcomment>
         <translation>とつげき</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="46"/>
+        <location filename="Data.cpp" line="47"/>
         <source>Traitement</source>
         <translatorcomment>Treatment</translatorcomment>
         <translation>ちりょう</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="46"/>
+        <location filename="Data.cpp" line="47"/>
         <source>Défense</source>
         <translatorcomment>Defend</translatorcomment>
         <translation>ぼうぎょ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="46"/>
+        <location filename="Data.cpp" line="47"/>
         <source>Combustion</source>
         <translatorcomment>Darkside</translatorcomment>
         <translation>あんこく</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="47"/>
+        <location filename="Data.cpp" line="48"/>
         <source>Arnica</source>
         <translatorcomment>Recover</translatorcomment>
         <translation>かいふく</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="47"/>
+        <location filename="Data.cpp" line="48"/>
         <source>Phagocyte</source>
         <translatorcomment>Absorb</translatorcomment>
         <translation>すいとる</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="47"/>
+        <location filename="Data.cpp" line="48"/>
         <source>Ranimer</source>
         <translatorcomment>Revive</translatorcomment>
         <translation>そせい</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="47"/>
+        <location filename="Data.cpp" line="48"/>
         <source>Nv Moins</source>
         <translatorcomment>LV Down</translatorcomment>
         <translation>レベルダウン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="47"/>
+        <location filename="Data.cpp" line="48"/>
         <source>Nv Plus</source>
         <translatorcomment>LV Up</translatorcomment>
         <translation>レベルアップ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="48"/>
+        <location filename="Data.cpp" line="49"/>
         <source>Kamikaze</source>
         <translatorcomment>Kamikaze</translatorcomment>
         <translation>じばく</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="48"/>
+        <location filename="Data.cpp" line="49"/>
         <source>Cannibale</source>
         <translatorcomment>Devour</translatorcomment>
         <translation>たべる</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="48"/>
+        <location filename="Data.cpp" line="49"/>
         <source>Mini Kikou</source>
         <translatorcomment>MiniMog</translatorcomment>
         <translation>コモーグリ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="48"/>
+        <location filename="Data.cpp" line="49"/>
         <source>HP+20%</source>
         <translatorcomment>HP+20%</translatorcomment>
         <translation>HP+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="48"/>
+        <location filename="Data.cpp" line="49"/>
         <source>HP+40%</source>
         <translatorcomment>HP+40%</translatorcomment>
         <translation>HP+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="49"/>
+        <location filename="Data.cpp" line="50"/>
         <source>HP+80%</source>
         <translatorcomment>HP+80%</translatorcomment>
         <translation>HP+80%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="49"/>
+        <location filename="Data.cpp" line="50"/>
         <source>Vgr+20%</source>
         <translatorcomment>Str+20%</translatorcomment>
         <translation>力+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="49"/>
+        <location filename="Data.cpp" line="50"/>
         <source>Vgr+40%</source>
         <translatorcomment>Str+40%</translatorcomment>
         <translation>力+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="49"/>
+        <location filename="Data.cpp" line="50"/>
         <source>Vgr+60%</source>
         <translatorcomment>Str+60%</translatorcomment>
         <translation>力+60%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="49"/>
+        <location filename="Data.cpp" line="50"/>
         <source>Dfs+20%</source>
         <translatorcomment>Vit+20%</translatorcomment>
         <translation>体力+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="50"/>
+        <location filename="Data.cpp" line="51"/>
         <source>Dfs+40%</source>
         <translatorcomment>Vit+40%</translatorcomment>
         <translation>体力+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="50"/>
+        <location filename="Data.cpp" line="51"/>
         <source>Dfs+60%</source>
         <translatorcomment>Vit+60%</translatorcomment>
         <translation>体力+60%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="50"/>
+        <location filename="Data.cpp" line="51"/>
         <source>Mgi+20%</source>
         <translatorcomment>Mag+20%</translatorcomment>
         <translation>魔力+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="50"/>
+        <location filename="Data.cpp" line="51"/>
         <source>Mgi+40%</source>
         <translatorcomment>Mag+40%</translatorcomment>
         <translation>魔力+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="50"/>
+        <location filename="Data.cpp" line="51"/>
         <source>Mgi+60%</source>
         <translatorcomment>Mag+60%</translatorcomment>
         <translation>魔力+60%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="51"/>
+        <location filename="Data.cpp" line="52"/>
         <source>Psy+20%</source>
         <translatorcomment>Spr+20%</translatorcomment>
         <translation>精神+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="51"/>
+        <location filename="Data.cpp" line="52"/>
         <source>Psy+40%</source>
         <translatorcomment>Spr+40%</translatorcomment>
         <translation>精神+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="51"/>
+        <location filename="Data.cpp" line="52"/>
         <source>Psy+60%</source>
         <translatorcomment>Spr+60%</translatorcomment>
         <translation>精神+60%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="51"/>
+        <location filename="Data.cpp" line="52"/>
         <source>Vit+20%</source>
         <translatorcomment>Spd+20%</translatorcomment>
         <translation>早さ+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="51"/>
+        <location filename="Data.cpp" line="52"/>
         <source>Vit+40%</source>
         <translatorcomment>Spd+40%</translatorcomment>
         <translation>早さ+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="52"/>
+        <location filename="Data.cpp" line="53"/>
         <source>Esq+30%</source>
         <translatorcomment>Eva+30%</translatorcomment>
         <translation>回避+30%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="52"/>
+        <location filename="Data.cpp" line="53"/>
         <source>Chc+50%</source>
         <translatorcomment>Luck+50%</translatorcomment>
         <translation>運+50%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="52"/>
+        <location filename="Data.cpp" line="53"/>
         <source>Piller</source>
         <translatorcomment>Mug</translatorcomment>
         <translation>ぶんどる</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="52"/>
+        <location filename="Data.cpp" line="53"/>
         <source>Schweitzer</source>
         <translatorcomment>Med Data</translatorcomment>
         <translation>くすりのちしき</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="52"/>
+        <location filename="Data.cpp" line="53"/>
         <source>Amorce</source>
         <translatorcomment>Counter</translatorcomment>
         <translation>カウンター</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="53"/>
+        <location filename="Data.cpp" line="54"/>
         <source>Backlash</source>
         <translatorcomment>Return Damage</translatorcomment>
         <translation>ダメージがえし</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="53"/>
+        <location filename="Data.cpp" line="54"/>
         <source>Empathie</source>
         <translatorcomment>Cover</translatorcomment>
         <translation>かばう</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="53"/>
+        <location filename="Data.cpp" line="54"/>
         <source>Genki</source>
         <translatorcomment>Initiative</translatorcomment>
         <translation>さきがけ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="53"/>
+        <location filename="Data.cpp" line="54"/>
         <source>Atlas-HP</source>
         <translatorcomment>Move-HP Up</translatorcomment>
         <translation>歩くとHP回復</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="54"/>
+        <location filename="Data.cpp" line="55"/>
         <source>Auto-Carapace</source>
         <translatorcomment>Auto-Protect</translatorcomment>
         <translation>オートプロテス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="55"/>
+        <location filename="Data.cpp" line="56"/>
         <source>Auto-Blindage</source>
         <translatorcomment>Auto-Shell</translatorcomment>
         <translation>オートシェル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="55"/>
+        <location filename="Data.cpp" line="56"/>
         <source>Auto-Boomerang</source>
         <translatorcomment>Auto-Reflect</translatorcomment>
         <translation>オートリフレク</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="55"/>
+        <location filename="Data.cpp" line="56"/>
         <source>Auto-Booster</source>
         <translatorcomment>Auto-Haste</translatorcomment>
         <translation>オートヘイスト</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="55"/>
+        <location filename="Data.cpp" line="56"/>
         <source>Auto-Potion</source>
         <translatorcomment>Auto-Potion</translatorcomment>
         <translation>オートポーション</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="55"/>
+        <location filename="Data.cpp" line="56"/>
         <source>DoublEco</source>
         <translatorcomment>Expendx2-1</translatorcomment>
         <translation>ダブル消費1</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="56"/>
+        <location filename="Data.cpp" line="57"/>
         <source>TriplEco</source>
         <translatorcomment>Expendx3-1</translatorcomment>
         <translation>トリプル消費1</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="56"/>
+        <location filename="Data.cpp" line="57"/>
         <source>Prudence</source>
         <translatorcomment>Alert</translatorcomment>
         <translation>けいかい</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="56"/>
+        <location filename="Data.cpp" line="57"/>
         <source>Clairvoyance</source>
         <translatorcomment>Move-Find</translatorcomment>
         <translation>隠しポイント発見</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="56"/>
+        <location filename="Data.cpp" line="57"/>
         <source>Mi-Combat</source>
         <translatorcomment>Enc-Half</translatorcomment>
         <translation>エンカウント半減</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="56"/>
+        <location filename="Data.cpp" line="57"/>
         <source>Freud</source>
         <comment>ability</comment>
         <translatorcomment>Ribbon</translatorcomment>
         <translation>リボン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="57"/>
+        <location filename="Data.cpp" line="58"/>
         <source>No-Combat</source>
         <translatorcomment>Enc-None</translatorcomment>
         <translation>エンカウントなし</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="57"/>
+        <location filename="Data.cpp" line="58"/>
         <source>Sensor</source>
         <translatorcomment>Rare Item</translatorcomment>
         <translation>レアアイテム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="57"/>
+        <location filename="Data.cpp" line="58"/>
         <source>Invoc+10%</source>
         <translatorcomment>SumMag+10%</translatorcomment>
         <translation>召喚魔法+10%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="57"/>
+        <location filename="Data.cpp" line="58"/>
         <source>Invoc+20%</source>
         <translatorcomment>SumMag+20%</translatorcomment>
         <translation>召喚魔法+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="57"/>
+        <location filename="Data.cpp" line="58"/>
         <source>Invoc+30%</source>
         <translatorcomment>SumMag+30%</translatorcomment>
         <translation>召喚魔法+30%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="58"/>
+        <location filename="Data.cpp" line="59"/>
         <source>Invoc+40%</source>
         <translatorcomment>SumMag+40%</translatorcomment>
         <translation>召喚魔法+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="58"/>
+        <location filename="Data.cpp" line="59"/>
         <source>HP-GF+10%</source>
         <translatorcomment>GFHP+10%</translatorcomment>
         <translation>GFHP+10%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="58"/>
+        <location filename="Data.cpp" line="59"/>
         <source>HP-GF+20%</source>
         <translatorcomment>GFHP+20%</translatorcomment>
         <translation>GFHP+20%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="58"/>
+        <location filename="Data.cpp" line="59"/>
         <source>HP-GF+30%</source>
         <translatorcomment>GFHP+30%</translatorcomment>
         <translation>GFHP+30%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="58"/>
+        <location filename="Data.cpp" line="59"/>
         <source>HP-GF+40%</source>
         <translatorcomment>GFHP+40%</translatorcomment>
         <translation>GFHP+40%</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="59"/>
+        <location filename="Data.cpp" line="60"/>
         <source>Turbo</source>
         <translatorcomment>Boost</translatorcomment>
         <translation>おうえん</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="59"/>
+        <location filename="Data.cpp" line="60"/>
         <source>Souk</source>
         <translatorcomment>Haggle</translatorcomment>
         <translation>値切る</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="59"/>
+        <location filename="Data.cpp" line="60"/>
         <source>Sentier</source>
         <translatorcomment>Sell-High</translatorcomment>
         <translation>高値で売る</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="59"/>
+        <location filename="Data.cpp" line="60"/>
         <source>Connaisseur</source>
         <translatorcomment>Familiar</translatorcomment>
         <translation>顔なじみ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="59"/>
+        <location filename="Data.cpp" line="60"/>
         <source>Boutiques</source>
         <translatorcomment>Call Shop</translatorcomment>
         <translation>ショップ呼び出し</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="60"/>
+        <location filename="Data.cpp" line="61"/>
         <source>Bazars</source>
         <translatorcomment>Junk Shop</translatorcomment>
         <translation>ジャンク屋呼び出し</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="60"/>
+        <location filename="Data.cpp" line="61"/>
         <source>Créa-Mgi-Cél</source>
         <translatorcomment>T Mag-RF</translatorcomment>
         <translation>雷魔法精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="60"/>
+        <location filename="Data.cpp" line="61"/>
         <source>Créa-Mgi-Gla</source>
         <translatorcomment>I Mag-RF</translatorcomment>
         <translation>冷気魔法精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="60"/>
+        <location filename="Data.cpp" line="61"/>
         <source>Créa-Mgi-Inc</source>
         <translatorcomment>F Mag-RF</translatorcomment>
         <translation>炎魔法精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="60"/>
+        <location filename="Data.cpp" line="61"/>
         <source>Créa-Mgi-Méd</source>
         <translatorcomment>L Mag-RF</translatorcomment>
         <translation>生命魔法精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="61"/>
+        <location filename="Data.cpp" line="62"/>
         <source>Créa-Mgi-Temp</source>
         <translatorcomment>Time Mag-RF</translatorcomment>
         <translation>時空魔法精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="61"/>
+        <location filename="Data.cpp" line="62"/>
         <source>Créa-Mgi-Mtl</source>
         <translatorcomment>ST Mag-RF</translatorcomment>
         <translation>ST魔法精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="61"/>
+        <location filename="Data.cpp" line="62"/>
         <source>Créa-Mgi-Pro</source>
         <translatorcomment>Supt Mag-RF</translatorcomment>
         <translation>サポート魔法精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="61"/>
+        <location filename="Data.cpp" line="62"/>
         <source>Créa-Mgi-Tab</source>
         <translatorcomment>Forbid Mag-RF</translatorcomment>
         <translation>禁断魔法精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="61"/>
+        <location filename="Data.cpp" line="62"/>
         <source>Créa-Mgi-Thér</source>
         <translatorcomment>Recov Med-RF</translatorcomment>
         <translation>回復薬精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="62"/>
+        <location filename="Data.cpp" line="63"/>
         <source>Créa-Mgi-Ana</source>
         <translatorcomment>ST Med-RF</translatorcomment>
         <translation>ST薬精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="62"/>
+        <location filename="Data.cpp" line="63"/>
         <source>Créa-Balles</source>
         <translatorcomment>Ammo-RF</translatorcomment>
         <translation>弾薬精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="62"/>
+        <location filename="Data.cpp" line="63"/>
         <source>Créa-Outils</source>
         <translatorcomment>Tool-RF</translatorcomment>
         <translation>道具精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="62"/>
+        <location filename="Data.cpp" line="63"/>
         <source>Créa-Thér-Tab</source>
         <translatorcomment>Forbid Med-RF</translatorcomment>
         <translation>禁断薬精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="62"/>
+        <location filename="Data.cpp" line="63"/>
         <source>Créa-Thér-GF</source>
         <translatorcomment>GFRecov Med-RF</translatorcomment>
         <translation>GF回復薬精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="63"/>
+        <location filename="Data.cpp" line="64"/>
         <source>Créa-Capa-GF</source>
         <translatorcomment>GFAbl Med-RF</translatorcomment>
         <translation>GF能力薬精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="63"/>
+        <location filename="Data.cpp" line="64"/>
         <source>Créa-Mgi-Plus</source>
         <translatorcomment>Mid Mag-RF</translatorcomment>
         <translation>中クラス魔法精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="63"/>
+        <location filename="Data.cpp" line="64"/>
         <source>Créa-Mgi-Max</source>
         <translatorcomment>High Mag-RF</translatorcomment>
         <translation>上クラス魔法精製</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="63"/>
+        <location filename="Data.cpp" line="64"/>
         <source>Soins NV +</source>
         <translatorcomment>Med LV Up</translatorcomment>
         <translation>薬レベルアップ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="63"/>
+        <location filename="Data.cpp" line="64"/>
         <source>Mode Carte</source>
         <translatorcomment>Card Mod</translatorcomment>
         <translation>カード変化</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="68"/>
+        <location filename="Data.cpp" line="69"/>
         <source>Brasier</source>
         <translatorcomment>Fire</translatorcomment>
         <translation>ファイア</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="68"/>
+        <location filename="Data.cpp" line="69"/>
         <source>Brasier+</source>
         <translatorcomment>Fira</translatorcomment>
         <translation>ファイラ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="68"/>
+        <location filename="Data.cpp" line="69"/>
         <source>BrasierX</source>
         <translatorcomment>Firaga</translatorcomment>
         <translation>ファイガ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="68"/>
+        <location filename="Data.cpp" line="69"/>
         <source>Glacier</source>
         <translatorcomment>Blizzard</translatorcomment>
         <translation>ブリザド</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="68"/>
+        <location filename="Data.cpp" line="69"/>
         <source>Glacier+</source>
         <translatorcomment>Blizzara</translatorcomment>
         <translation>ブリザラ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="69"/>
+        <location filename="Data.cpp" line="70"/>
         <source>GlacierX</source>
         <translatorcomment>Blizzaga</translatorcomment>
         <translation>ブリザガ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="69"/>
+        <location filename="Data.cpp" line="70"/>
         <source>Foudre</source>
         <translatorcomment>Thunder</translatorcomment>
         <translation>サンダー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="69"/>
+        <location filename="Data.cpp" line="70"/>
         <source>Foudre+</source>
         <translatorcomment>Thundara</translatorcomment>
         <translation>サンダラ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="69"/>
+        <location filename="Data.cpp" line="70"/>
         <source>FoudreX</source>
         <translatorcomment>Thundaga</translatorcomment>
         <translation>サンダガ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="69"/>
+        <location filename="Data.cpp" line="70"/>
         <source>Rafale</source>
         <translatorcomment>Aero</translatorcomment>
         <translation>エアロ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="69"/>
+        <location filename="Data.cpp" line="70"/>
         <source>Cyanure</source>
         <translatorcomment>Bio</translatorcomment>
         <translation>バイオ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="70"/>
+        <location filename="Data.cpp" line="71"/>
         <source>Quart</source>
         <translatorcomment>Demi</translatorcomment>
         <translation>グラビデ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="70"/>
+        <location filename="Data.cpp" line="71"/>
         <source>Sidéral</source>
         <translatorcomment>Holy</translatorcomment>
         <translation>ホーリー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="70"/>
+        <location filename="Data.cpp" line="71"/>
         <source>Fournaise</source>
         <translatorcomment>Flare</translatorcomment>
         <translation>フレア</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="70"/>
+        <location filename="Data.cpp" line="71"/>
         <source>Météore</source>
         <translatorcomment>Meteor</translatorcomment>
         <translation>メテオ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="70"/>
+        <location filename="Data.cpp" line="71"/>
         <source>Quake</source>
         <translatorcomment>Quake</translatorcomment>
         <translation>クエイク</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="70"/>
+        <location filename="Data.cpp" line="71"/>
         <source>Tornade</source>
         <translatorcomment>Tornado</translatorcomment>
         <translation>トルネド</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="70"/>
+        <location filename="Data.cpp" line="71"/>
         <source>Ultima</source>
         <translatorcomment>Ultima</translatorcomment>
         <translation>アルテマ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Apocalypse</source>
         <translatorcomment>Apocalypse</translatorcomment>
         <translation>アポカリプス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Soin</source>
         <translatorcomment>Cure</translatorcomment>
         <translation>ケアル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Soin Max</source>
         <translatorcomment>Curaga</translatorcomment>
         <translation>ケアルガ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Vie</source>
         <translatorcomment>Life</translatorcomment>
         <translation>レイズ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Vie Max</source>
         <translatorcomment>Full-life</translatorcomment>
         <translation>アレイズ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Récup</source>
         <translatorcomment>Regen</translatorcomment>
         <translation>リジェネ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Esuna</source>
         <translatorcomment>Esuna</translatorcomment>
         <translation>エスナ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Anti-sort</source>
         <translatorcomment>Dispel</translatorcomment>
         <translation>デスペル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Carapace</source>
         <translatorcomment>Protect</translatorcomment>
         <translation>プロテス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Blindage</source>
         <translatorcomment>Shell</translatorcomment>
         <translation>シェル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Aura</source>
         <translatorcomment>Aura</translatorcomment>
         <translation>オーラ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Double</source>
         <translatorcomment>Double</translatorcomment>
         <translation>ダブル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Triple</source>
         <translatorcomment>Triple</translatorcomment>
         <translation>トリプル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Booster</source>
         <translatorcomment>Haste</translatorcomment>
         <translation>ヘイスト</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Somni</source>
         <translatorcomment>Slow</translatorcomment>
         <translation>スロウ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Stop</source>
         <translatorcomment>Stop</translatorcomment>
         <translation>ストップ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Cécité</source>
         <translatorcomment>Blind</translatorcomment>
         <translation>ブライン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Folie</source>
         <translatorcomment>Confuse</translatorcomment>
         <translation>コンフュ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Morphée</source>
         <translatorcomment>Sleep</translatorcomment>
         <translation>スリプル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Aphasie</source>
         <translatorcomment>Silence</translatorcomment>
         <translation>サイレス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Mégalith</source>
         <translatorcomment>Break</translatorcomment>
         <translation>ブレイク</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="73"/>
+        <location filename="Data.cpp" line="74"/>
         <source>Ankou</source>
         <translatorcomment>Death</translatorcomment>
         <translation>デス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Saignée</source>
         <translatorcomment>Drain</translatorcomment>
         <translation>ドレイン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Supplice</source>
         <translatorcomment>Pain</translatorcomment>
         <translation>ペイン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Furie</source>
         <translatorcomment>Berserk</translatorcomment>
         <translation>バーサク</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Décubitus</source>
         <translatorcomment>Float</translatorcomment>
         <translation>レビテト</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Zombie</source>
         <translatorcomment>Zombie</translatorcomment>
         <translation>ゾンビー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Meltdown</source>
         <translatorcomment>Meltdown</translatorcomment>
         <translation>メルトン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Scan</source>
         <translatorcomment>Scan</translatorcomment>
         <translation>ライブラ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="74"/>
+        <location filename="Data.cpp" line="75"/>
         <source>Joobu</source>
         <translatorcomment>Full-cure</translatorcomment>
         <translation>フルケア</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="75"/>
+        <location filename="Data.cpp" line="76"/>
         <source>Wall</source>
         <translatorcomment>Wall</translatorcomment>
         <translation>ウォール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="75"/>
+        <location filename="Data.cpp" line="76"/>
         <source>Arkange</source>
         <translatorcomment>Rapture</translatorcomment>
         <translation>レビテガ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="75"/>
+        <location filename="Data.cpp" line="76"/>
         <source>The End</source>
         <translatorcomment>The End</translatorcomment>
         <translation>ジエンド</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="75"/>
+        <location filename="Data.cpp" line="76"/>
         <source>Percent</source>
         <translatorcomment>Percent</translatorcomment>
         <translation>パセント</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="75"/>
+        <location filename="Data.cpp" line="76"/>
         <source>Catastrophe</source>
         <translatorcomment>Catastrophe</translatorcomment>
         <translation>カタスト</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="80"/>
+        <location filename="Data.cpp" line="81"/>
         <source>Potion</source>
         <translatorcomment>Potion</translatorcomment>
         <translation>ポーション</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="80"/>
+        <location filename="Data.cpp" line="81"/>
         <source>Potion+</source>
         <translatorcomment>Potion+</translatorcomment>
         <translation>ポーション改</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="80"/>
+        <location filename="Data.cpp" line="81"/>
         <source>Hypra-Potion</source>
         <translatorcomment>Hi-Potion</translatorcomment>
         <translation>ハイポーション</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="80"/>
+        <location filename="Data.cpp" line="81"/>
         <source>Maxi potion</source>
         <translatorcomment>Hi-Potion+</translatorcomment>
         <translation>ハイポーション改</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="80"/>
+        <location filename="Data.cpp" line="81"/>
         <source>Potion totale</source>
         <translatorcomment>X-Potion</translatorcomment>
         <translation>エクスポーション</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="81"/>
+        <location filename="Data.cpp" line="82"/>
         <source>Méga potion</source>
         <translatorcomment>Mega-Potion</translatorcomment>
         <translation>メガポーション</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="81"/>
+        <location filename="Data.cpp" line="82"/>
         <source>MT-Psy</source>
         <translatorcomment>Phoenix Down</translatorcomment>
         <translation>フェニックスの尾</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="81"/>
+        <location filename="Data.cpp" line="82"/>
         <source>Maxi MT-Psy</source>
         <translatorcomment>Mega Phoenix</translatorcomment>
         <translation>メガフェニックス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="81"/>
+        <location filename="Data.cpp" line="82"/>
         <source>Elixir</source>
         <translatorcomment>Elixir</translatorcomment>
         <translation>エリクサー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="81"/>
+        <location filename="Data.cpp" line="82"/>
         <source>Mégalixir</source>
         <translatorcomment>Megalixir</translatorcomment>
         <translation>ラストエリクサー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="81"/>
+        <location filename="Data.cpp" line="82"/>
         <source>Antidote</source>
         <translatorcomment>Antidote</translatorcomment>
         <translation>毒消し</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="82"/>
+        <location filename="Data.cpp" line="83"/>
         <source>Défijeur</source>
         <translatorcomment>Soft</translatorcomment>
         <translation>金の針</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="82"/>
+        <location filename="Data.cpp" line="83"/>
         <source>Lasik</source>
         <translatorcomment>Eye Drops</translatorcomment>
         <translation>目薬</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="82"/>
+        <location filename="Data.cpp" line="83"/>
         <source>Bocca</source>
         <translatorcomment>Echo Screen</translatorcomment>
         <translation>山彦草</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="82"/>
+        <location filename="Data.cpp" line="83"/>
         <source>Eau bénite</source>
         <translatorcomment>Holy Water</translatorcomment>
         <translation>聖水</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="82"/>
+        <location filename="Data.cpp" line="83"/>
         <source>Remède</source>
         <translatorcomment>Remedy</translatorcomment>
         <translation>万能薬</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="82"/>
+        <location filename="Data.cpp" line="83"/>
         <source>Remède +</source>
         <translatorcomment>Remedy+</translatorcomment>
         <translation>万能薬改</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="83"/>
+        <location filename="Data.cpp" line="84"/>
         <source>1-20-Syble</source>
         <translatorcomment>Hero-trial</translatorcomment>
         <translation>英雄の薬試作型</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="83"/>
+        <location filename="Data.cpp" line="84"/>
         <source>Invulnérable</source>
         <translatorcomment>Hero</translatorcomment>
         <translation>英雄の薬</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="83"/>
+        <location filename="Data.cpp" line="84"/>
         <source>1-destructible</source>
         <translatorcomment>Holy War-trial</translatorcomment>
         <translation>聖戦の薬試作型</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="83"/>
+        <location filename="Data.cpp" line="84"/>
         <source>Croisade</source>
         <translatorcomment>Holy War</translatorcomment>
         <translation>聖戦の薬</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="83"/>
+        <location filename="Data.cpp" line="84"/>
         <source>Roc cosse</source>
         <translatorcomment>Shell Stone</translatorcomment>
         <translation>シェルストーン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="84"/>
+        <location filename="Data.cpp" line="85"/>
         <source>Roc carapace</source>
         <translatorcomment>Protect Stone</translatorcomment>
         <translation>プロテスストーン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="84"/>
+        <location filename="Data.cpp" line="85"/>
         <source>Roc d&apos;Aura</source>
         <translatorcomment>Aura Stone</translatorcomment>
         <translation>オーラストーン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="84"/>
+        <location filename="Data.cpp" line="85"/>
         <source>Roc mortel</source>
         <translatorcomment>Death Stone</translatorcomment>
         <translation>デスストーン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="84"/>
+        <location filename="Data.cpp" line="85"/>
         <source>Roc sacré</source>
         <translatorcomment>Holy Stone</translatorcomment>
         <translation>ホーリーストーン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="84"/>
+        <location filename="Data.cpp" line="85"/>
         <source>Roc flamboyant</source>
         <translatorcomment>Flare Stone</translatorcomment>
         <translation>フレアストーン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="85"/>
+        <location filename="Data.cpp" line="86"/>
         <source>Roc Météore</source>
         <translatorcomment>Meteor Stone</translatorcomment>
         <translation>メテオストーン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="85"/>
+        <location filename="Data.cpp" line="86"/>
         <source>Roc Ultima</source>
         <translatorcomment>Ultima Stone</translatorcomment>
         <translation>アルテマストーン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="85"/>
+        <location filename="Data.cpp" line="86"/>
         <source>ChocoLégume</source>
         <translatorcomment>Gysahl Greens</translatorcomment>
         <translation>ギサールの野菜</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="85"/>
+        <location filename="Data.cpp" line="86"/>
         <source>Pen Pal</source>
         <translatorcomment>Friendship</translatorcomment>
         <translation>ゆうじょうのあかし</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="86"/>
+        <location filename="Data.cpp" line="87"/>
         <source>Red Kross</source>
         <translatorcomment>Tent</translatorcomment>
         <translation>テント</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="86"/>
+        <location filename="Data.cpp" line="87"/>
         <source>Zoologie</source>
         <translatorcomment>Pet House</translatorcomment>
         <translation>ペットハウス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="86"/>
+        <location filename="Data.cpp" line="87"/>
         <source>Saindoux</source>
         <translatorcomment>Cottage</translatorcomment>
         <translation>コテージ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="86"/>
+        <location filename="Data.cpp" line="87"/>
         <source>Potion GF</source>
         <translatorcomment>G-Potion</translatorcomment>
         <translation>Ｇポーション</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="86"/>
+        <location filename="Data.cpp" line="87"/>
         <source>Potion GF +</source>
         <translatorcomment>G-Hi-Potion</translatorcomment>
         <translation>Ｇハイポーション</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="87"/>
+        <location filename="Data.cpp" line="88"/>
         <source>Mégapotion GF</source>
         <translatorcomment>G-Mega-Potion</translatorcomment>
         <translation>Ｇメガポーション</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="87"/>
+        <location filename="Data.cpp" line="88"/>
         <source>Sel marin</source>
         <translatorcomment>G-Returner</translatorcomment>
         <translation>Gリターナー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="87"/>
+        <location filename="Data.cpp" line="88"/>
         <source>Carte baptême</source>
         <translatorcomment>Rename Card</translatorcomment>
         <translation>リネームカード</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="87"/>
+        <location filename="Data.cpp" line="88"/>
         <source>Décapaciteur</source>
         <translatorcomment>Amnesia Greens</translatorcomment>
         <translation>忘れ草</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="87"/>
+        <location filename="Data.cpp" line="88"/>
         <source>Livret HP-A</source>
         <translatorcomment>HP-J Scroll</translatorcomment>
         <translation>ＨＰの書</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="88"/>
+        <location filename="Data.cpp" line="89"/>
         <source>Livret Vgr-A</source>
         <translatorcomment>Str-J Scroll</translatorcomment>
         <translation>力の書</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="88"/>
+        <location filename="Data.cpp" line="89"/>
         <source>Livret Dfs-A</source>
         <translatorcomment>Vit-J Scroll</translatorcomment>
         <translation>体力の書</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="88"/>
+        <location filename="Data.cpp" line="89"/>
         <source>Livret Mgi-A</source>
         <translatorcomment>Mag-J Scroll</translatorcomment>
         <translation>魔力の書</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="88"/>
+        <location filename="Data.cpp" line="89"/>
         <source>Livret Psy-A</source>
         <translatorcomment>Spr-J Scroll</translatorcomment>
         <translation>精神の書</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="88"/>
+        <location filename="Data.cpp" line="89"/>
         <source>Livret Vts-A</source>
         <translatorcomment>Spd-J Scroll</translatorcomment>
         <translation>早さの書</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="89"/>
+        <location filename="Data.cpp" line="90"/>
         <source>Livret Chc-A</source>
         <translatorcomment>Luck-J Scroll</translatorcomment>
         <translation>運の書</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="89"/>
+        <location filename="Data.cpp" line="90"/>
         <source>Shadow</source>
         <translatorcomment>Aegis Amulet</translatorcomment>
         <translation>エイジスの守り</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="89"/>
+        <location filename="Data.cpp" line="90"/>
         <source>Assaut Elé</source>
         <translatorcomment>Elem Atk</translatorcomment>
         <translation>エレメントアタック</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="89"/>
+        <location filename="Data.cpp" line="90"/>
         <source>Antichoc Elé</source>
         <translatorcomment>Elem Guard</translatorcomment>
         <translation>エレメントガード</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="89"/>
+        <location filename="Data.cpp" line="90"/>
         <source>Assaut Mtl</source>
         <translatorcomment>Status Atk</translatorcomment>
         <translation>ステータスアタック</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="90"/>
+        <location filename="Data.cpp" line="91"/>
         <source>Antichoc Mtl</source>
         <translatorcomment>Status Guard</translatorcomment>
         <translation>ステータスガード</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="90"/>
+        <location filename="Data.cpp" line="91"/>
         <source>Roc Rosette</source>
         <translatorcomment>Rosetta Stone</translatorcomment>
         <translation>ロゼッタ石</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="90"/>
+        <location filename="Data.cpp" line="91"/>
         <source>GrimoMagic</source>
         <translatorcomment>Magic Scroll</translatorcomment>
         <translation>魔法の書</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="90"/>
+        <location filename="Data.cpp" line="91"/>
         <source>GrimoForce</source>
         <translatorcomment>GF Scroll</translatorcomment>
         <translation>Ｇ．Ｆ．の書</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="90"/>
+        <location filename="Data.cpp" line="91"/>
         <source>GrimoVole</source>
         <translatorcomment>Draw Scroll</translatorcomment>
         <translation>ドローの書</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="91"/>
+        <location filename="Data.cpp" line="92"/>
         <source>GrimObjets</source>
         <translatorcomment>Item Scroll</translatorcomment>
         <translation>アイテムの書</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="91"/>
+        <location filename="Data.cpp" line="92"/>
         <source>Vegas Feel</source>
         <translatorcomment>Gambler Spirit</translatorcomment>
         <translation>勝負師の魂</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="91"/>
+        <location filename="Data.cpp" line="92"/>
         <source>Sanatorium</source>
         <translatorcomment>Healing Ring</translatorcomment>
         <translation>いやしの指輪</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="91"/>
+        <location filename="Data.cpp" line="92"/>
         <source>MétemPsy</source>
         <translatorcomment>Phoenix Spirit</translatorcomment>
         <translation>フェニックスの魂</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="91"/>
+        <location filename="Data.cpp" line="92"/>
         <source>Bandage</source>
         <translatorcomment>Med Kit</translatorcomment>
         <translation>救急セット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="91"/>
+        <location filename="Data.cpp" line="92"/>
         <source>Nova</source>
         <translatorcomment>Bomb Spirit</translatorcomment>
         <translation>ボムの魂</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="92"/>
+        <location filename="Data.cpp" line="93"/>
         <source>Régime</source>
         <translatorcomment>Hungry Cookpot</translatorcomment>
         <translation>食欲魔神のナベ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="92"/>
+        <location filename="Data.cpp" line="93"/>
         <source>Kikkou Mania</source>
         <translatorcomment>Mog&apos;s Amulet</translatorcomment>
         <translation>モグのお守り</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="92"/>
+        <location filename="Data.cpp" line="93"/>
         <source>Samâdhi</source>
         <translatorcomment>Steel Pipe</translatorcomment>
         <translation>鉄パイプ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="92"/>
+        <location filename="Data.cpp" line="93"/>
         <source>Zodiaque</source>
         <translatorcomment>Star Fragment</translatorcomment>
         <translation>星々のかけら</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="92"/>
+        <location filename="Data.cpp" line="93"/>
         <source>Nuclide</source>
         <translatorcomment>Energy Crystal</translatorcomment>
         <translation>エネルギー結晶体</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="92"/>
+        <location filename="Data.cpp" line="93"/>
         <source>Sacrum</source>
         <translatorcomment>Samantha Soul</translatorcomment>
         <translation>ソウルオブサマサ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="93"/>
+        <location filename="Data.cpp" line="94"/>
         <source>Billet</source>
         <translatorcomment>Healing Mail</translatorcomment>
         <translation>ヒーリングメイル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="93"/>
+        <location filename="Data.cpp" line="94"/>
         <source>Armure d&apos;or</source>
         <translatorcomment>Gold Armor</translatorcomment>
         <translation>ゴールドアーマー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="93"/>
+        <location filename="Data.cpp" line="94"/>
         <source>Cuirasse</source>
         <translatorcomment>Diamond Armor</translatorcomment>
         <translation>ダイヤアーマー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="93"/>
+        <location filename="Data.cpp" line="94"/>
         <source>Anneau Récup</source>
         <translatorcomment>Regen Ring</translatorcomment>
         <translation>復活の指輪</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="93"/>
+        <location filename="Data.cpp" line="94"/>
         <source>Alliance</source>
         <translatorcomment>Giant&apos;s Ring</translatorcomment>
         <translation>巨人の指輪</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="93"/>
+        <location filename="Data.cpp" line="94"/>
         <source>Vierge</source>
         <comment>item1</comment>
         <translatorcomment>Silver Mail</translatorcomment>
         <translation>銀の腕輪</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="94"/>
+        <location filename="Data.cpp" line="95"/>
         <source>Bague Gaêa</source>
         <translatorcomment>Gaea&apos;s Ring</translatorcomment>
         <translation>ガイアの指輪</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="94"/>
+        <location filename="Data.cpp" line="95"/>
         <source>Vitamine</source>
         <translatorcomment>Strength Love</translatorcomment>
         <translation>ちからだすき</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="94"/>
+        <location filename="Data.cpp" line="95"/>
         <source>Sagou</source>
         <translatorcomment>Power Wrist</translatorcomment>
         <translation>パワーリスト</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="94"/>
+        <location filename="Data.cpp" line="95"/>
         <source>Sagette</source>
         <translatorcomment>Hyper Wrist</translatorcomment>
         <translation>ハイパーリスト</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="94"/>
+        <location filename="Data.cpp" line="95"/>
         <source>Coquille</source>
         <translatorcomment>Turtle Shell</translatorcomment>
         <translation>カメのこうら</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="94"/>
+        <location filename="Data.cpp" line="95"/>
         <source>Halcyon</source>
         <translatorcomment>Orihalcon</translatorcomment>
         <translation>オリハルコン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="95"/>
+        <location filename="Data.cpp" line="96"/>
         <source>Adamantine</source>
         <translatorcomment>Adamantine</translatorcomment>
         <translation>アダマンタイン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="95"/>
+        <location filename="Data.cpp" line="96"/>
         <source>Obole</source>
         <translatorcomment>Rune Armlet</translatorcomment>
         <translation>ルーンの腕輪</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="95"/>
+        <location filename="Data.cpp" line="96"/>
         <source>Tao</source>
         <translatorcomment>Force Armlet</translatorcomment>
         <translation>フォースの腕輪</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="95"/>
+        <location filename="Data.cpp" line="96"/>
         <source>Lacan</source>
         <translatorcomment>Magic Armlet</translatorcomment>
         <translation>魔神の腕輪</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="95"/>
+        <location filename="Data.cpp" line="96"/>
         <source>Garcinord</source>
         <translatorcomment>Circlet</translatorcomment>
         <translation>サークレット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="95"/>
+        <location filename="Data.cpp" line="96"/>
         <source>Merlin</source>
         <translatorcomment>Hypno Crown</translatorcomment>
         <translation>ヒュプノクラウン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="96"/>
+        <location filename="Data.cpp" line="97"/>
         <source>Magax</source>
         <translatorcomment>Royal Crown</translatorcomment>
         <translation>ロイヤルクラウン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="96"/>
+        <location filename="Data.cpp" line="97"/>
         <source>Injection</source>
         <translatorcomment>Jet Engine</translatorcomment>
         <translation>ジェットエンジン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="96"/>
+        <location filename="Data.cpp" line="97"/>
         <source>SuperSonic</source>
         <translatorcomment>Rocket Engine</translatorcomment>
         <translation>ロケットエンジン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="96"/>
+        <location filename="Data.cpp" line="97"/>
         <source>Pied de biche</source>
         <translatorcomment>Moon Curtain</translatorcomment>
         <translation>月のカーテン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="96"/>
+        <location filename="Data.cpp" line="97"/>
         <source>Ecaille</source>
         <translatorcomment>Steel Curtain</translatorcomment>
         <translation>鉄のカーテン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="96"/>
+        <location filename="Data.cpp" line="97"/>
         <source>Tasmania</source>
         <translatorcomment>Glow Curtain</translatorcomment>
         <translation>光のカーテン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="97"/>
+        <location filename="Data.cpp" line="98"/>
         <source>Speedy</source>
         <translatorcomment>Accelerator</translatorcomment>
         <translation>加速装置</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="97"/>
+        <location filename="Data.cpp" line="98"/>
         <source>Réactor</source>
         <translatorcomment>Monk&apos;s Code</translatorcomment>
         <translation>モンクの心得</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="97"/>
+        <location filename="Data.cpp" line="98"/>
         <source>Protector</source>
         <translatorcomment>Knight&apos;s Code</translatorcomment>
         <translation>ナイトの心得</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="97"/>
+        <location filename="Data.cpp" line="98"/>
         <source>Pasteur</source>
         <translatorcomment>Doc&apos;s Code</translatorcomment>
         <translation>医術の心得</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="97"/>
+        <location filename="Data.cpp" line="98"/>
         <source>Manivelle</source>
         <translatorcomment>Hundred Needles</translatorcomment>
         <translation>１００本針</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="97"/>
+        <location filename="Data.cpp" line="98"/>
         <source>Trilogie</source>
         <translatorcomment>Three Stars</translatorcomment>
         <translation>スリースターズ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="98"/>
+        <location filename="Data.cpp" line="99"/>
         <source>Balles normales</source>
         <translatorcomment>Normal Ammo</translatorcomment>
         <translation>通常弾</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="98"/>
+        <location filename="Data.cpp" line="99"/>
         <source>Mitra-balles</source>
         <translatorcomment>Shotgun Ammo</translatorcomment>
         <translation>散弾</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="98"/>
+        <location filename="Data.cpp" line="99"/>
         <source>Dark balles</source>
         <translatorcomment>Dark Ammo</translatorcomment>
         <translation>暗黒弾</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="98"/>
+        <location filename="Data.cpp" line="99"/>
         <source>Balles foudre</source>
         <translatorcomment>Fire Ammo</translatorcomment>
         <translation>火炎弾</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="98"/>
+        <location filename="Data.cpp" line="99"/>
         <source>Freud</source>
         <comment>item</comment>
         <translatorcomment>Ribbon</translatorcomment>
         <translation>リボン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="99"/>
+        <location filename="Data.cpp" line="100"/>
         <source>Balles tornade</source>
         <translatorcomment>Demolition Ammo</translatorcomment>
         <translation>破壊弾</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="99"/>
+        <location filename="Data.cpp" line="100"/>
         <source>Balles véloces</source>
         <translatorcomment>Fast Ammo</translatorcomment>
         <translation>速射弾</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="99"/>
+        <location filename="Data.cpp" line="100"/>
         <source>Balles anti-char</source>
         <translatorcomment>AP Ammo</translatorcomment>
         <translation>徹甲弾</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="99"/>
+        <location filename="Data.cpp" line="100"/>
         <source>Balles Pulsar</source>
         <translatorcomment>Pulse Ammo</translatorcomment>
         <translation>波動弾</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="99"/>
+        <location filename="Data.cpp" line="100"/>
         <source>Caillou magik</source>
         <translatorcomment>M-Stone Piece</translatorcomment>
         <translation>魔石のかけら</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="100"/>
+        <location filename="Data.cpp" line="101"/>
         <source>Roc initiatique</source>
         <translatorcomment>Magic Stone</translatorcomment>
         <translation>魔石</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="100"/>
+        <location filename="Data.cpp" line="101"/>
         <source>Roc féerique</source>
         <translatorcomment>Wizard Stone</translatorcomment>
         <translation>魔導石</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="100"/>
+        <location filename="Data.cpp" line="101"/>
         <source>Tentacule</source>
         <translatorcomment>Ochu Tentacle</translatorcomment>
         <translation>オチューの触手</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="100"/>
+        <location filename="Data.cpp" line="101"/>
         <source>Onde bénite</source>
         <translatorcomment>Healing Water</translatorcomment>
         <translation>いやしの水</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="100"/>
+        <location filename="Data.cpp" line="101"/>
         <source>Plumage</source>
         <translatorcomment>Cockatrice Pinion</translatorcomment>
         <translation>コカトリスの羽</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="101"/>
+        <location filename="Data.cpp" line="102"/>
         <source>Poudre Zombie</source>
         <translatorcomment>Zombie Powder</translatorcomment>
         <translation>ゾンビパウダー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="101"/>
+        <location filename="Data.cpp" line="102"/>
         <source>Bottes de 7km</source>
         <translatorcomment>Lightweight</translatorcomment>
         <translation>ダッシュシューズ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="101"/>
+        <location filename="Data.cpp" line="102"/>
         <source>9 inch nail</source>
         <translatorcomment>Sharp Spike</translatorcomment>
         <translation>とがった爪</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="101"/>
+        <location filename="Data.cpp" line="102"/>
         <source>Enclume</source>
         <translatorcomment>Screw</translatorcomment>
         <translation>ネジ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="101"/>
+        <location filename="Data.cpp" line="102"/>
         <source>Cimeterre</source>
         <translatorcomment>Saw Blade</translatorcomment>
         <translation>ノコギリの刃</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="102"/>
+        <location filename="Data.cpp" line="103"/>
         <source>Corne</source>
         <translatorcomment>Mesmerize Blade</translatorcomment>
         <translation>メズマライズの刃</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="102"/>
+        <location filename="Data.cpp" line="103"/>
         <source>Sanguine</source>
         <translatorcomment>Vampire Fang</translatorcomment>
         <translation>吸血の牙</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="102"/>
+        <location filename="Data.cpp" line="103"/>
         <source>EuFurysant</source>
         <translatorcomment>Fury Fragment</translatorcomment>
         <translation>闘気のかけら</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="102"/>
+        <location filename="Data.cpp" line="103"/>
         <source>Epée trompeuse</source>
         <translatorcomment>Betrayal Sword</translatorcomment>
         <translation>味方殺しの剣</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="102"/>
+        <location filename="Data.cpp" line="103"/>
         <source>Poudre Morphée</source>
         <translatorcomment>Sleep Powder</translatorcomment>
         <translation>眠り粉</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="103"/>
+        <location filename="Data.cpp" line="104"/>
         <source>Anneau de vie</source>
         <translatorcomment>Life Ring</translatorcomment>
         <translation>命の指輪</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="103"/>
+        <location filename="Data.cpp" line="104"/>
         <source>Lochness</source>
         <translatorcomment>Dragon Fang</translatorcomment>
         <translation>竜の牙</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="103"/>
+        <location filename="Data.cpp" line="104"/>
         <source>U-Boat</source>
         <translatorcomment>Spider Web</translatorcomment>
         <translation>クモの糸</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="103"/>
+        <location filename="Data.cpp" line="104"/>
         <source>Etoile</source>
         <translatorcomment>Coral Fragment</translatorcomment>
         <translation>サンゴのかけら</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="103"/>
+        <location filename="Data.cpp" line="104"/>
         <source>Weirdo</source>
         <translatorcomment>Curse Spike</translatorcomment>
         <translation>呪いの爪</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="103"/>
+        <location filename="Data.cpp" line="104"/>
         <source>Gen-X</source>
         <translatorcomment>Black Hole</translatorcomment>
         <translation>ブラックホール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="104"/>
+        <location filename="Data.cpp" line="105"/>
         <source>Fluide</source>
         <translatorcomment>Water Crystal</translatorcomment>
         <translation>水の結晶</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="104"/>
+        <location filename="Data.cpp" line="105"/>
         <source>M-Double</source>
         <translatorcomment>Missile</translatorcomment>
         <translation>ミサイル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="104"/>
+        <location filename="Data.cpp" line="105"/>
         <source>House</source>
         <translatorcomment>Mystery Fluid</translatorcomment>
         <translation>謎の液体</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="104"/>
+        <location filename="Data.cpp" line="105"/>
         <source>Chevrotine</source>
         <translatorcomment>Running Fire</translatorcomment>
         <translation>牙式連発銃</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="104"/>
+        <location filename="Data.cpp" line="105"/>
         <source>Canicule</source>
         <translatorcomment>Inferno Fang</translatorcomment>
         <translation>火竜の牙</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="104"/>
+        <location filename="Data.cpp" line="105"/>
         <source>Germe</source>
         <translatorcomment>Malboro Tentacle</translatorcomment>
         <translation>モルボルの触手</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="105"/>
+        <location filename="Data.cpp" line="106"/>
         <source>Rhône</source>
         <translatorcomment>Whisper</translatorcomment>
         <translation>風のささやき</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="105"/>
+        <location filename="Data.cpp" line="106"/>
         <source>Rayon</source>
         <translatorcomment>Laser Cannon</translatorcomment>
         <translation>レーザーキャノン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="105"/>
+        <location filename="Data.cpp" line="106"/>
         <source>V-Choc</source>
         <translatorcomment>Power Generator</translatorcomment>
         <translation>高出力発生装置</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="105"/>
+        <location filename="Data.cpp" line="106"/>
         <source>H-Espace</source>
         <translatorcomment>Dark Matter</translatorcomment>
         <translation>ダークマター</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="105"/>
+        <location filename="Data.cpp" line="106"/>
         <source>Hot Rock</source>
         <translatorcomment>Bomb Fragment</translatorcomment>
         <translation>ボムのかけら</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="105"/>
+        <location filename="Data.cpp" line="106"/>
         <source>Vierge</source>
         <comment>item2</comment>
         <translatorcomment>Barrier</translatorcomment>
         <translation>バリアシステム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="106"/>
+        <location filename="Data.cpp" line="107"/>
         <source>Molaire</source>
         <translatorcomment>Red Fang</translatorcomment>
         <translation>赤い牙</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="106"/>
+        <location filename="Data.cpp" line="107"/>
         <source>Blizzard</source>
         <translatorcomment>Arctic Wind</translatorcomment>
         <translation>南極の風</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="106"/>
+        <location filename="Data.cpp" line="107"/>
         <source>Nunatak</source>
         <translatorcomment>North Wind</translatorcomment>
         <translation>北極の風</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="106"/>
+        <location filename="Data.cpp" line="107"/>
         <source>Gemma Luce</source>
         <translatorcomment>Dynamo Stone</translatorcomment>
         <translation>ダイナモ石</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="106"/>
+        <location filename="Data.cpp" line="107"/>
         <source>Aigrette</source>
         <translatorcomment>Shear Feather</translatorcomment>
         <translation>風切り羽</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="106"/>
+        <location filename="Data.cpp" line="107"/>
         <source>Canine</source>
         <translatorcomment>Venom Fang</translatorcomment>
         <translation>毒の牙</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="107"/>
+        <location filename="Data.cpp" line="108"/>
         <source>Globe d&apos;acier</source>
         <translatorcomment>Steel Orb</translatorcomment>
         <translation>鉄球</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="107"/>
+        <location filename="Data.cpp" line="108"/>
         <source>Roc lunaire</source>
         <translatorcomment>Moon Stone</translatorcomment>
         <translation>月の石</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="107"/>
+        <location filename="Data.cpp" line="108"/>
         <source>Fémur</source>
         <translatorcomment>Dino Bone</translatorcomment>
         <translation>恐竜の骨</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="107"/>
+        <location filename="Data.cpp" line="108"/>
         <source>Aquilon</source>
         <translatorcomment>Windmill</translatorcomment>
         <translation>風車</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="107"/>
+        <location filename="Data.cpp" line="108"/>
         <source>Derme</source>
         <translatorcomment>Dragon Skin</translatorcomment>
         <translation>竜の皮</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="107"/>
+        <location filename="Data.cpp" line="108"/>
         <source>Zygène</source>
         <translatorcomment>Fish Fin</translatorcomment>
         <translation>サカナのヒレ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="108"/>
+        <location filename="Data.cpp" line="109"/>
         <source>Shark</source>
         <translatorcomment>Dragon Fin</translatorcomment>
         <translation>竜のウロコ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="108"/>
+        <location filename="Data.cpp" line="109"/>
         <source>Poudre Aphasie</source>
         <translatorcomment>Silence Powder</translatorcomment>
         <translation>沈黙の粉</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="108"/>
+        <location filename="Data.cpp" line="109"/>
         <source>Venin</source>
         <translatorcomment>Poison Powder</translatorcomment>
         <translation>毒の粉</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="108"/>
+        <location filename="Data.cpp" line="109"/>
         <source>Revenant</source>
         <translatorcomment>Dead Spirit</translatorcomment>
         <translation>死者の魂</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="108"/>
+        <location filename="Data.cpp" line="109"/>
         <source>Désosseur </source>
         <translatorcomment>Chef&apos;s Knife</translatorcomment>
         <translation>ほうちょう</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="108"/>
+        <location filename="Data.cpp" line="109"/>
         <source>Kaktos</source>
         <translatorcomment>Cactus Thorn</translatorcomment>
         <translation>サボテンのトゲ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="109"/>
+        <location filename="Data.cpp" line="110"/>
         <source>Roc Shaman</source>
         <translatorcomment>Shaman Stone</translatorcomment>
         <translation>賢者の石</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="109"/>
+        <location filename="Data.cpp" line="110"/>
         <source>Essence</source>
         <translatorcomment>Fuel</translatorcomment>
         <translation>燃料</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="109"/>
+        <location filename="Data.cpp" line="110"/>
         <source>Comtesse Cochon</source>
         <translatorcomment>Girl Net Door</translatorcomment>
         <translation>となりのカノジョ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="109"/>
+        <location filename="Data.cpp" line="110"/>
         <source>Missive d&apos;Edea</source>
         <translatorcomment>Sorceress&apos; Letter</translatorcomment>
         <translation>魔女のてがみ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="109"/>
+        <location filename="Data.cpp" line="110"/>
         <source>Collier Chocobo</source>
         <translatorcomment>Chocobo&apos;s Tag</translatorcomment>
         <translation>チョコボの名札</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="110"/>
+        <location filename="Data.cpp" line="111"/>
         <source>Collier chien</source>
         <translatorcomment>Pet Nametag</translatorcomment>
         <translation>ペットの名札</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="110"/>
+        <location filename="Data.cpp" line="111"/>
         <source>Bague du chef</source>
         <translatorcomment>Solomon Ring</translatorcomment>
         <translation>ソロモンの指輪</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="110"/>
+        <location filename="Data.cpp" line="111"/>
         <source>Aladore</source>
         <translatorcomment>Magical Lamp</translatorcomment>
         <translation>魔法のランプ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="53"/>
+        <location filename="Data.cpp" line="54"/>
         <source>Bonus HP</source>
         <comment>ability</comment>
         <translatorcomment>HP Bonus</translatorcomment>
         <translation>HPボーナス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="54"/>
+        <location filename="Data.cpp" line="55"/>
         <source>Bonus Vgr</source>
         <comment>ability</comment>
         <translatorcomment>Str Bonus</translatorcomment>
         <translation>力ボーナス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="54"/>
+        <location filename="Data.cpp" line="55"/>
         <source>Bonus Dfs</source>
         <comment>ability</comment>
         <translatorcomment>Vit Bonus</translatorcomment>
         <translation>体力ボーナス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="54"/>
+        <location filename="Data.cpp" line="55"/>
         <source>Bonus Mgi</source>
         <comment>ability</comment>
         <translatorcomment>Mag Bonus</translatorcomment>
         <translation>魔力ボーナス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="54"/>
+        <location filename="Data.cpp" line="55"/>
         <source>Bonus Psy</source>
         <comment>ability</comment>
         <translatorcomment>Spr Bonus</translatorcomment>
         <translation>精神ボーナス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="110"/>
+        <location filename="Data.cpp" line="111"/>
         <source>Bonus Hp</source>
         <comment>item</comment>
         <translatorcomment>HP Up</translatorcomment>
         <translation>ＨＰアップ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="110"/>
+        <location filename="Data.cpp" line="111"/>
         <source>Bonus Vgr</source>
         <comment>item</comment>
         <translatorcomment>Str Up</translatorcomment>
         <translation>パワーアップ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="111"/>
+        <location filename="Data.cpp" line="112"/>
         <source>Bonus Dfs</source>
         <comment>item</comment>
         <translatorcomment>Vit Up</translatorcomment>
         <translation>ガードアップ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="111"/>
+        <location filename="Data.cpp" line="112"/>
         <source>Bonus Mgi</source>
         <comment>item</comment>
         <translatorcomment>Mag Up</translatorcomment>
         <translation>マジックアップ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="111"/>
+        <location filename="Data.cpp" line="112"/>
         <source>Bonus Psy</source>
         <comment>item</comment>
         <translatorcomment>Spr Up</translatorcomment>
         <translation>マインドアップ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="111"/>
+        <location filename="Data.cpp" line="112"/>
         <source>Bonus Vts</source>
         <comment>item</comment>
         <translatorcomment>Spd Up</translatorcomment>
         <translation>スピードアップ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="111"/>
+        <location filename="Data.cpp" line="112"/>
         <source>Bonus Chc</source>
         <comment>item</comment>
         <translatorcomment>Luck Up</translatorcomment>
         <translation>ラックアップ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="112"/>
+        <location filename="Data.cpp" line="113"/>
         <source>Amour bestial</source>
         <translatorcomment>LuvLuv G</translatorcomment>
         <translation>ラブラブG</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="112"/>
+        <location filename="Data.cpp" line="113"/>
         <source>F.F.F. Fév</source>
         <translatorcomment>Weapons Mon 1st</translatorcomment>
         <translation>月刊武器 創刊号</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="112"/>
+        <location filename="Data.cpp" line="113"/>
         <source>F.F.F. Mar</source>
         <translatorcomment>Weapons Mon Mar</translatorcomment>
         <translation>月刊武器 3月号</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="112"/>
+        <location filename="Data.cpp" line="113"/>
         <source>F.F.F. Avr</source>
         <translatorcomment>Weapons Mon Apr</translatorcomment>
         <translation>月刊武器 4月号</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="112"/>
+        <location filename="Data.cpp" line="113"/>
         <source>F.F.F. Mai</source>
         <translatorcomment>Weapons Mon May</translatorcomment>
         <translation>月刊武器 5月号</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="113"/>
+        <location filename="Data.cpp" line="114"/>
         <source>F.F.F. Jun</source>
         <translatorcomment>Weapons Mon Jun</translatorcomment>
         <translation>月刊武器 6月号</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="113"/>
+        <location filename="Data.cpp" line="114"/>
         <source>F.F.F. Jul</source>
         <translatorcomment>Weapons Mon Jul</translatorcomment>
         <translation>月刊武器 7月号</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="113"/>
+        <location filename="Data.cpp" line="114"/>
         <source>F.F.F. Aoû</source>
         <translatorcomment>Weapons Mon Aug</translatorcomment>
         <translation>月刊武器 8月号</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="113"/>
+        <location filename="Data.cpp" line="114"/>
         <source>Baston mag 1</source>
         <translatorcomment>Combat King 001</translatorcomment>
         <translation>格闘王 001</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="113"/>
+        <location filename="Data.cpp" line="114"/>
         <source>Baston mag 2</source>
         <translatorcomment>Combat King 002</translatorcomment>
         <translation>格闘王 002</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="114"/>
+        <location filename="Data.cpp" line="115"/>
         <source>Baston mag 3</source>
         <translatorcomment>Combat King 003</translatorcomment>
         <translation>格闘王 003</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="114"/>
+        <location filename="Data.cpp" line="115"/>
         <source>Baston mag 4</source>
         <translatorcomment>Combat King 004</translatorcomment>
         <translation>格闘王 004</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="114"/>
+        <location filename="Data.cpp" line="115"/>
         <source>Baston mag 5</source>
         <translatorcomment>Combat King 005</translatorcomment>
         <translation>格闘王 005</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="114"/>
+        <location filename="Data.cpp" line="115"/>
         <source>L&apos;A D bêtes 1</source>
         <translatorcomment>Pet Pals Vol.1</translatorcomment>
         <translation>ペット通信 Vol.1</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="114"/>
+        <location filename="Data.cpp" line="115"/>
         <source>L&apos;A D bêtes 2</source>
         <translatorcomment>Pet Pals Vol.2</translatorcomment>
         <translation>ペット通信 Vol.2</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="115"/>
+        <location filename="Data.cpp" line="116"/>
         <source>L&apos;A D bêtes 3</source>
         <translatorcomment>Pet Pals Vol.3</translatorcomment>
         <translation>ペット通信 Vol.3</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="115"/>
+        <location filename="Data.cpp" line="116"/>
         <source>L&apos;A D bêtes 4</source>
         <translatorcomment>Pet Pals Vol.4</translatorcomment>
         <translation>ペット通信 Vol.4</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="115"/>
+        <location filename="Data.cpp" line="116"/>
         <source>L&apos;A D bêtes 5</source>
         <translatorcomment>Pet Pals Vol.5</translatorcomment>
         <translation>ペット通信 Vol.5</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="115"/>
+        <location filename="Data.cpp" line="116"/>
         <source>L&apos;A D bêtes 6</source>
         <translatorcomment>Pet Pals Vol.6</translatorcomment>
         <translation>ペット通信 Vol.6</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="115"/>
+        <location filename="Data.cpp" line="116"/>
         <source>Occult Fan I</source>
         <translatorcomment>Occult Fan I</translatorcomment>
         <translation>オカルトファン I</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="116"/>
+        <location filename="Data.cpp" line="117"/>
         <source>Occult Fan II</source>
         <translatorcomment>Occult Fan II</translatorcomment>
         <translation>オカルトファン II</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="116"/>
+        <location filename="Data.cpp" line="117"/>
         <source>Occult Fan III</source>
         <translatorcomment>Occult Fan III</translatorcomment>
         <translation>オカルトファン III</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="116"/>
+        <location filename="Data.cpp" line="117"/>
         <source>Occult Fan IV</source>
         <translatorcomment>Occult Fan IV</translatorcomment>
         <translation>オカルトファン IV</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="141"/>
+        <location filename="Data.cpp" line="154"/>
         <source>Pistolame</source>
         <translatorcomment>Revolver</translatorcomment>
         <translation>リボルバー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="141"/>
+        <location filename="Data.cpp" line="154"/>
         <source>Nacre Blade</source>
         <translatorcomment>Shear Trigger</translatorcomment>
         <translation>キアストレート</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="141"/>
+        <location filename="Data.cpp" line="154"/>
         <source>Dragon Blade</source>
         <translatorcomment>Cutting Trigger</translatorcomment>
         <translation>カッテングトリガー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="141"/>
+        <location filename="Data.cpp" line="154"/>
         <source>Sabreur</source>
         <translatorcomment>Flame Saber</translatorcomment>
         <translation>フレイムタン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="141"/>
+        <location filename="Data.cpp" line="154"/>
         <source>Katana</source>
         <translatorcomment>Twin Lance</translatorcomment>
         <translation>ランスオブスリット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="141"/>
+        <location filename="Data.cpp" line="154"/>
         <source>Kendo</source>
         <translatorcomment>Punishment</translatorcomment>
         <translation>クライム＆ペナルティ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="141"/>
+        <location filename="Data.cpp" line="154"/>
         <source>Lionheart</source>
         <translatorcomment>Lion Heart</translatorcomment>
         <translation>エンドオブハート</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="142"/>
+        <location filename="Data.cpp" line="155"/>
         <source>Metal Gloves</source>
         <translatorcomment>Metal Knuckle</translatorcomment>
         <translation>メタルナックル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="142"/>
+        <location filename="Data.cpp" line="155"/>
         <source>Maverick</source>
         <translatorcomment>Maverick</translatorcomment>
         <translation>マーベリック</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="142"/>
+        <location filename="Data.cpp" line="155"/>
         <source>Gauntlets</source>
         <translatorcomment>Gauntlet</translatorcomment>
         <translation>ガントレット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="142"/>
+        <location filename="Data.cpp" line="155"/>
         <source>Ehrgeiz</source>
         <translatorcomment>Ehrgeiz</translatorcomment>
         <translation>エアガイツ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="143"/>
+        <location filename="Data.cpp" line="156"/>
         <source>W.W.West</source>
         <translatorcomment>Valiant</translatorcomment>
         <translation>バリアント</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="143"/>
+        <location filename="Data.cpp" line="156"/>
         <source>Roosevelt</source>
         <translatorcomment>Ulysses</translatorcomment>
         <translation>ユリシーズ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="143"/>
+        <location filename="Data.cpp" line="156"/>
         <source>Bertha</source>
         <translatorcomment>Bismarck</translatorcomment>
         <translation>ビスマルク</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="143"/>
+        <location filename="Data.cpp" line="156"/>
         <source>Steel Gun</source>
         <translatorcomment>Exeter</translatorcomment>
         <translation>エクゼター</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="144"/>
+        <location filename="Data.cpp" line="157"/>
         <source>Gibet</source>
         <translatorcomment>Chain Whip</translatorcomment>
         <translation>チェーンウィップ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="144"/>
+        <location filename="Data.cpp" line="157"/>
         <source>Totally S.M.</source>
         <translatorcomment>Slaying Tail</translatorcomment>
         <translation>スレイプニルテイル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="144"/>
+        <location filename="Data.cpp" line="157"/>
         <source>Red Scorpio</source>
         <translatorcomment>Red Scorpion</translatorcomment>
         <translation>レッドスコルピオン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="144"/>
+        <location filename="Data.cpp" line="157"/>
         <source>Smiley</source>
         <translatorcomment>Save the Queen</translatorcomment>
         <translation>セイブ・ザ・クイーン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="145"/>
+        <location filename="Data.cpp" line="158"/>
         <source>Rotator</source>
         <translatorcomment>Pinwheel</translatorcomment>
         <translation>円月輪</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="145"/>
+        <location filename="Data.cpp" line="158"/>
         <source>Walkyrie</source>
         <translatorcomment>Valkyrie</translatorcomment>
         <translation>ヴァルキリー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="145"/>
+        <location filename="Data.cpp" line="158"/>
         <source>Ninja Sun</source>
         <translatorcomment>Rising Sun</translatorcomment>
         <translation>ライジングサン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="145"/>
+        <location filename="Data.cpp" line="158"/>
         <source>Ptérodactyle</source>
         <translatorcomment>Cardinal</translatorcomment>
         <translation>カーディナル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="145"/>
+        <location filename="Data.cpp" line="158"/>
         <source>Tronçonneur</source>
         <translatorcomment>Shooting Star</translatorcomment>
         <translation>シューティングスター</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="146"/>
+        <location filename="Data.cpp" line="159"/>
         <source>Nunchak Red</source>
         <translatorcomment>Flail</translatorcomment>
         <translation>フレイル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="146"/>
+        <location filename="Data.cpp" line="159"/>
         <source>Nunchak Blue</source>
         <translatorcomment>Morning Star</translatorcomment>
         <translation>モーニングスター</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="146"/>
+        <location filename="Data.cpp" line="159"/>
         <source>Islam Star</source>
         <translatorcomment>Crescent Wish</translatorcomment>
         <translation>クレセントウィッシュ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="147"/>
+        <location filename="Data.cpp" line="160"/>
         <source>Hyperion</source>
         <translatorcomment>Hyperion</translatorcomment>
         <translation>ハイペリオン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="147"/>
+        <location filename="Data.cpp" line="160"/>
         <source>Nada</source>
         <translatorcomment>None</translatorcomment>
         <translation>なし</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="147"/>
+        <location filename="Data.cpp" line="160"/>
         <source>Kalachnikov</source>
         <translatorcomment>Machine Gun</translatorcomment>
         <translation>マシンガン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="147"/>
+        <location filename="Data.cpp" line="160"/>
         <source>Katal</source>
         <translatorcomment>Katal</translatorcomment>
         <translation>カタール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="147"/>
+        <location filename="Data.cpp" line="160"/>
         <source>Harpoon</source>
         <translatorcomment>Harpoon</translatorcomment>
         <translation>ハープーン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="152"/>
-        <location filename="Data.cpp" line="211"/>
-        <location filename="Data.cpp" line="812"/>
+        <location filename="Data.cpp" line="165"/>
+        <location filename="Data.cpp" line="224"/>
+        <location filename="Data.cpp" line="826"/>
         <source>Squall</source>
         <translatorcomment>Squall</translatorcomment>
         <translation>スコール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="152"/>
-        <location filename="Data.cpp" line="210"/>
+        <location filename="Data.cpp" line="165"/>
+        <location filename="Data.cpp" line="223"/>
         <source>Zell</source>
         <translatorcomment>Zell</translatorcomment>
         <translation>ゼル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="152"/>
-        <location filename="Data.cpp" line="210"/>
+        <location filename="Data.cpp" line="165"/>
+        <location filename="Data.cpp" line="223"/>
         <source>Irvine</source>
         <translatorcomment>Irvine</translatorcomment>
         <translation>アーヴァイン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="152"/>
-        <location filename="Data.cpp" line="210"/>
+        <location filename="Data.cpp" line="165"/>
+        <location filename="Data.cpp" line="223"/>
         <source>Quistis</source>
         <translatorcomment>Quistis</translatorcomment>
         <translation>キスティス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="152"/>
-        <location filename="Data.cpp" line="211"/>
+        <location filename="Data.cpp" line="165"/>
+        <location filename="Data.cpp" line="224"/>
         <source>Linoa</source>
         <translatorcomment>Rinoa</translatorcomment>
         <translation>リノア</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="153"/>
-        <location filename="Data.cpp" line="210"/>
+        <location filename="Data.cpp" line="166"/>
+        <location filename="Data.cpp" line="223"/>
         <source>Selphie</source>
         <translatorcomment>Selphie</translatorcomment>
         <translation>セルフィー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="153"/>
-        <location filename="Data.cpp" line="211"/>
+        <location filename="Data.cpp" line="166"/>
+        <location filename="Data.cpp" line="224"/>
         <source>Seifer</source>
         <translatorcomment>Seifer</translatorcomment>
         <translation>サイファー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="153"/>
-        <location filename="Data.cpp" line="211"/>
+        <location filename="Data.cpp" line="166"/>
+        <location filename="Data.cpp" line="224"/>
         <source>Edea</source>
         <translatorcomment>Edea</translatorcomment>
         <translation>イデア</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="153"/>
-        <location filename="Data.cpp" line="210"/>
+        <location filename="Data.cpp" line="166"/>
+        <location filename="Data.cpp" line="223"/>
         <source>Laguna</source>
         <translatorcomment>Laguna</translatorcomment>
         <translation>ラグナ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="153"/>
-        <location filename="Data.cpp" line="210"/>
+        <location filename="Data.cpp" line="166"/>
+        <location filename="Data.cpp" line="223"/>
         <source>Kiros</source>
         <translatorcomment>Kiros</translatorcomment>
         <translation>キロス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="154"/>
-        <location filename="Data.cpp" line="209"/>
+        <location filename="Data.cpp" line="167"/>
+        <location filename="Data.cpp" line="222"/>
         <source>Ward</source>
         <translatorcomment>Ward</translatorcomment>
         <translation>ウォード</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="154"/>
+        <location filename="Data.cpp" line="167"/>
         <source>Cronos</source>
         <translatorcomment>Griever</translatorcomment>
         <translation>グリーヴァ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="154"/>
+        <location filename="Data.cpp" line="167"/>
         <source>MiniMog</source>
         <translatorcomment>MiniMog</translatorcomment>
         <translation>コモーグリ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="154"/>
+        <location filename="Data.cpp" line="167"/>
         <source>Angel</source>
         <translatorcomment>Angelo</translatorcomment>
         <translation>アンジェロ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="207"/>
+        <location filename="Data.cpp" line="220"/>
         <source>Shiva</source>
         <comment>card</comment>
         <translatorcomment>Shiva</translatorcomment>
         <translation>シヴァ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="207"/>
+        <location filename="Data.cpp" line="220"/>
         <source>Ifrit</source>
         <comment>card</comment>
         <translatorcomment>Ifrit</translatorcomment>
         <translation>イフリート</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="207"/>
+        <location filename="Data.cpp" line="220"/>
         <source>Ondine</source>
         <comment>card</comment>
         <translatorcomment>Siren</translatorcomment>
         <translation>セイレーン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="207"/>
+        <location filename="Data.cpp" line="220"/>
         <source>Tauros</source>
         <comment>card</comment>
         <translatorcomment>Sacred</translatorcomment>
         <translation>セクレト</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="207"/>
+        <location filename="Data.cpp" line="220"/>
         <source>Taurux</source>
         <comment>card</comment>
         <translatorcomment>Minotaur</translatorcomment>
         <translation>ミノタウロス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="208"/>
+        <location filename="Data.cpp" line="221"/>
         <source>Ahuri</source>
         <comment>card</comment>
         <translatorcomment>Carbuncle</translatorcomment>
         <translation>カーバンクル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="208"/>
+        <location filename="Data.cpp" line="221"/>
         <source>Nosferatu</source>
         <comment>card</comment>
         <translatorcomment>Diablos</translatorcomment>
         <translation>ディアボロス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="208"/>
+        <location filename="Data.cpp" line="221"/>
         <source>Leviathan</source>
         <comment>card</comment>
         <translatorcomment>Leviathan</translatorcomment>
         <translation>リヴァイアサン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="208"/>
+        <location filename="Data.cpp" line="221"/>
         <source>Odin</source>
         <comment>card</comment>
         <translatorcomment>Odin</translatorcomment>
         <translation>オーディン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="208"/>
+        <location filename="Data.cpp" line="221"/>
         <source>Zéphyr</source>
         <comment>card</comment>
         <translatorcomment>Pandemona</translatorcomment>
         <translation>パンデモニウム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="209"/>
+        <location filename="Data.cpp" line="222"/>
         <source>Alexander</source>
         <comment>card</comment>
         <translatorcomment>Alexander</translatorcomment>
         <translation>アレクサンダー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="209"/>
+        <location filename="Data.cpp" line="222"/>
         <source>Phénix</source>
         <comment>card</comment>
         <translatorcomment>Phoenix</translatorcomment>
         <translation>フェニックス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="209"/>
+        <location filename="Data.cpp" line="222"/>
         <source>Bahamut</source>
         <comment>card</comment>
         <translatorcomment>Bahamut</translatorcomment>
         <translation>バハムート</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="209"/>
+        <location filename="Data.cpp" line="222"/>
         <source>Helltrain</source>
         <comment>card</comment>
         <translatorcomment>Doomtrain</translatorcomment>
         <translation>グラシャラボラス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="209"/>
+        <location filename="Data.cpp" line="222"/>
         <source>Orbital</source>
         <comment>card</comment>
         <translatorcomment>Eden</translatorcomment>
         <translation>エデン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="159"/>
+        <location filename="Data.cpp" line="172"/>
         <source>Golgotha</source>
         <comment>gf</comment>
         <translatorcomment>Quezacotl</translatorcomment>
@@ -5436,2057 +5441,2172 @@ By default Hyne attempts to automatically sign saves, but in case of error, you 
         <translation type="obsolete">ワイルドフック</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="167"/>
+        <location filename="Data.cpp" line="180"/>
         <source>Top Punch</source>
         <translatorcomment>Punch Rush</translatorcomment>
         <translation>ラッシュパンチ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="69"/>
+        <location filename="Data.cpp" line="70"/>
         <source>H2o</source>
         <translation>ウォータ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="71"/>
+        <location filename="Data.cpp" line="72"/>
         <source>Soin +</source>
         <translation>ケアルラ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="72"/>
+        <location filename="Data.cpp" line="73"/>
         <source>Boomrg</source>
         <translation>リフレク</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Plaines d&apos;Arkland - Balamb</source>
         <comment>1</comment>
         <translatorcomment>Balamb- Alcauld Plains</translatorcomment>
         <translation>バラム・アルクラド平野</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Monts Gaulg - Balamb</source>
         <comment>2</comment>
         <translatorcomment>Balamb- Gaulg Mountains</translatorcomment>
         <translation>バラム・グアルグ山脈</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Baie de Rinaul - Balamb</source>
         <comment>3</comment>
         <translatorcomment>Balamb- Rinaul Coast</translatorcomment>
         <translation>バラム・リナール海岸</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Cap Raha - Balamb</source>
         <comment>4</comment>
         <translatorcomment>Balamb- Raha Cape</translatorcomment>
         <translation>バラム・ラハ岬</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Forêt de Rosfall - Timber</source>
         <comment>5</comment>
         <translatorcomment>Timber- Roshfall Forest</translatorcomment>
         <translation>ティンバー・ロスフォールの森</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Mandy Beach - Timber</source>
         <comment>6</comment>
         <translatorcomment>Timber- Mandy Beach</translatorcomment>
         <translation>ティンバー・マンデービーチ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Lac Obel - Timber</source>
         <comment>7</comment>
         <translatorcomment>Timber- Obel Lake</translatorcomment>
         <translation>ティンバー・オーベール湖</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Vallée de Lanker - Timber</source>
         <comment>8</comment>
         <translatorcomment>Timber- Lanker Plains</translatorcomment>
         <translation>ティンバー・ランカー平原</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Ile Nantakhet - Timber</source>
         <comment>9</comment>
         <translatorcomment>Timber- Nanchucket Island</translatorcomment>
         <translation>ティンバー・ナンタケット島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Yaulny Canyon - Timber</source>
         <comment>10</comment>
         <translatorcomment>Timber- Yaulny Canyon</translatorcomment>
         <translation>ティンバー・ヤルニ渓谷</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Val Hasberry - Dollet</source>
         <comment>11</comment>
         <translatorcomment>Dollet- Hasberry Plains</translatorcomment>
         <translation>ドール・ヘスペリデス平原</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Cap Holy Glory - Dollet</source>
         <comment>12</comment>
         <translatorcomment>Dollet- Holy Glory Cape</translatorcomment>
         <translation>ドール・ホーリーグローリー岬</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Longhorn Island - Dollet</source>
         <comment>13</comment>
         <translatorcomment>Dollet- Long Horn Island</translatorcomment>
         <translation>ドール・ロングホーン島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Péninsule Malgo - Dollet</source>
         <comment>14</comment>
         <translatorcomment>Dollet- Malgo Peninsula</translatorcomment>
         <translation>ドール・マルゴー半島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="121"/>
+        <location filename="Data.cpp" line="122"/>
         <source>Plateau Monterosa - Galbadia</source>
         <comment>15</comment>
         <translatorcomment>Galbadia- Monterosa Plateau</translatorcomment>
         <translation>ガルバディア・モンテローザ高原</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Lallapalooza Canyon - Galbadia</source>
         <comment>16</comment>
         <translatorcomment>Galbadia- Lallapalooza Canyon</translatorcomment>
         <translation>ガルバディア・ロラパルーザ渓谷</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Shenand Hill - Timber</source>
         <comment>17</comment>
         <translatorcomment>Timber- Shenand Hill</translatorcomment>
         <translation>ティンバー・シェナンドー丘陵</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Péninsule Gotland - Galbadia</source>
         <comment>18</comment>
         <translatorcomment>Galbadia- Gotland Peninsula</translatorcomment>
         <translation>ガルバディア・ゴートランド半島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Ile de l&apos;Enfer - Galbadia</source>
         <comment>19</comment>
         <translatorcomment>Island Closest to Hell</translatorcomment>
         <translation>ガルバディア・地獄に一番近い島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Plaine Galbadienne</source>
         <comment>20</comment>
         <translatorcomment>Great Plains of Galbadia</translatorcomment>
         <translation>ガルバディア大平原</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Wilburn Hill - Galbadia</source>
         <comment>21</comment>
         <translatorcomment>Galbadia- Wilburn Hill</translatorcomment>
         <translation>ガルバディア・ウィルバーン丘陵</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Archipel Rem - Galbadia</source>
         <comment>22</comment>
         <translatorcomment>Galbadia- Rem Archipelago</translatorcomment>
         <translation>ガルバディア・レム諸島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Dingo Désert - Galbadia</source>
         <comment>23</comment>
         <translatorcomment>Galbadia- Dingo Desert</translatorcomment>
         <translation>ガルバディア・ディンゴー砂漠</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Cap Winhill</source>
         <comment>24</comment>
         <translatorcomment>Winhill- Winhill Bluffs</translatorcomment>
         <translation>ウィンヒル・ウィンヒル丘陵</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Archipel Humphrey - Winhill</source>
         <comment>25</comment>
         <translatorcomment>Winhill- Humphrey Archipelago</translatorcomment>
         <translation>ウィンヒル・ハンフリー諸島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Ile Winter - Trabia</source>
         <comment>26</comment>
         <translatorcomment>Trabia- Winter Island</translatorcomment>
         <translation>トラビア・ヴィンター島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Val de Solvard - Trabia</source>
         <comment>27</comment>
         <translatorcomment>Trabia- Sorbald Snowfield</translatorcomment>
         <translation>トラビア・ソルバールド雪原</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Crête d&apos;Eldbeak - Trabia</source>
         <comment>28</comment>
         <translatorcomment>Trabia- Eldbeak Peninsula</translatorcomment>
         <translation>トラビア・エルドビーク半島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Plaine d&apos;Hawkind - Trabia</source>
         <comment>30</comment>
         <translatorcomment>Trabia- Hawkwind Plains</translatorcomment>
         <translation>トラビア・ホークウィンド平原</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="122"/>
+        <location filename="Data.cpp" line="123"/>
         <source>Atoll Albatross - Trabia</source>
         <comment>31</comment>
         <translatorcomment>Trabia- Albatross Archipelago</translatorcomment>
         <translation>トラビア・アルバトロス諸島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Vallon de Bika - Trabia</source>
         <comment>32</comment>
         <translatorcomment>Trabia- Bika Snowfield</translatorcomment>
         <translation>トラビア・ビッケ雪原</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Péninsule Thor - Trabia</source>
         <comment>33</comment>
         <translatorcomment>Trabia- Thor Peninsula</translatorcomment>
         <translation>トラビア・トール半島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Crête d&apos;Heath - Trabia</source>
         <comment>35</comment>
         <translatorcomment>Trabia- Heath Peninsula</translatorcomment>
         <translation>トラビア・ヒアデス半島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Trabia Crater - Trabia</source>
         <comment>36</comment>
         <translatorcomment>Trabia- Trabia Crater</translatorcomment>
         <translation>トラビア・トラビアクレーター</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Mont Vienne - Trabia</source>
         <comment>37</comment>
         <translatorcomment>Trabia- Vienne Mountains</translatorcomment>
         <translation>トラビア・ヴェーン山脈</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Plaine de Mordor - Esthar</source>
         <comment>38</comment>
         <translatorcomment>Esthar- Mordred Plains</translatorcomment>
         <translation>エスタ・モルドレット平原</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Mont Nortes - Esthar</source>
         <comment>39</comment>
         <translatorcomment>Esthar- Nortes Mountains</translatorcomment>
         <translation>エスタ・ノルテス山脈</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Atoll Fulcura - Esthar</source>
         <comment>40</comment>
         <translatorcomment>Esthar- Fulcura Archipelago</translatorcomment>
         <translation>エスタ・フニクリフニクラ諸島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Forêt Grandidi - Esthar</source>
         <comment>41</comment>
         <translatorcomment>Esthar- Grandidi Forest</translatorcomment>
         <translation>エスタ・グランディディエリの森</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Iles Millefeuilles - Esthar</source>
         <comment>42</comment>
         <translatorcomment>Esthar- Millefeuille Archipelago</translatorcomment>
         <translation>エスタ・ミルフィーユ諸島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Grandes plaines d&apos;Esthar</source>
         <comment>43</comment>
         <translatorcomment>Great Plains of Esthar</translatorcomment>
         <translation>エスタ大平原</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Esthar City</source>
         <comment>44</comment>
         <translatorcomment>Esthar City</translatorcomment>
         <translation>エスタシティ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Salt Lake - Esthar</source>
         <comment>45</comment>
         <translatorcomment>Esthar- Great Salt Lake</translatorcomment>
         <translation>エスタ・大塩湖</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Côte Ouest - Esthar</source>
         <comment>46</comment>
         <translatorcomment>Esthar- West Coast</translatorcomment>
         <translation>エスタ・ウェストコースト</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="123"/>
+        <location filename="Data.cpp" line="124"/>
         <source>Mont Sollet - Esthar</source>
         <comment>47</comment>
         <translatorcomment>Esthar- Sollet Mountains</translatorcomment>
         <translation>エスタ・スール山脈</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Vallée d&apos;Abadan - Esthar</source>
         <comment>48</comment>
         <translatorcomment>Esthar- Abadan Plains</translatorcomment>
         <translation>エスタ・アバンダン平原</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Ile Minde - Esthar</source>
         <comment>49</comment>
         <translatorcomment>Esthar- Minde Island</translatorcomment>
         <translation>エスタ・スカラマンガ島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Désert Kashkabald - Esthar</source>
         <comment>50</comment>
         <translatorcomment>Esthar- Kashkabald Desert</translatorcomment>
         <translation>エスタ・カシュクバール砂漠</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Ile Paradisiaque - Esthar</source>
         <comment>51</comment>
         <translatorcomment>Island Closest to Heaven</translatorcomment>
         <translation>エスタ・天国に一番近い島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Pic de Talle - Esthar</source>
         <comment>52</comment>
         <translatorcomment>Esthar- Talle Mountains</translatorcomment>
         <translation>エスタ・タル山脈</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Atoll Shalmal - Esthar</source>
         <comment>53</comment>
         <translatorcomment>Esthar- Shalmal Peninsula</translatorcomment>
         <translation>エスタ・シャルマール半島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Vallée de Lolestern - Centra</source>
         <comment>54</comment>
         <translatorcomment>Centra- Lolestern Plains</translatorcomment>
         <translation>セントラ・ロレスターン平原</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Aiguille d&apos;Almage - Centra</source>
         <comment>55</comment>
         <translatorcomment>Centra- Almaj Mountains</translatorcomment>
         <translation>セントラ・アルマージ山脈</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Vallon Lenown - Centra</source>
         <comment>56</comment>
         <translatorcomment>Centra- Lenown Plains</translatorcomment>
         <translation>セントラ・レナーン平原</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Cap de l&apos;espoir - Centra</source>
         <comment>57</comment>
         <translatorcomment>Centra- Cape of Good Hope</translatorcomment>
         <translation>セントラ・グッドホープ岬</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Mont Yorn - Centra</source>
         <comment>58</comment>
         <translatorcomment>Centra- Yorn Mountains</translatorcomment>
         <translation>セントラ・ヨーン山脈</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Ile Pampa - Esthar</source>
         <comment>59</comment>
         <translatorcomment>Esthar- Cactuar Island</translatorcomment>
         <translation>エスタ・サボテンダーアイランド</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Val Serengetti - Centra</source>
         <comment>60</comment>
         <translatorcomment>Centra- Serengetti Plains</translatorcomment>
         <translation>セントラ・セレンゲッティ平原</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Péninsule Nectalle - Centra</source>
         <comment>61</comment>
         <translatorcomment>Centra- Nectar Peninsula</translatorcomment>
         <translation>セントラ・ネクタール半島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Centra Crater - Centra</source>
         <comment>62</comment>
         <translatorcomment>Centra- Centra Crater</translatorcomment>
         <translation>セントラ・セントラクレーター</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="124"/>
+        <location filename="Data.cpp" line="125"/>
         <source>Ile Poccarahi - Centra</source>
         <comment>63</comment>
         <translatorcomment>Centra- Poccarahi Island</translatorcomment>
         <translation>セントラ・ポッカラヒレリア島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Bibliothèque - BGU</source>
         <comment>64</comment>
         <translatorcomment>B-Garden- Library</translatorcomment>
         <translation>Ｂガーデン・図書館</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Entrée - BGU</source>
         <comment>65</comment>
         <translatorcomment>B-Garden- Front Gate</translatorcomment>
         <translation>バラムガーデン・正門</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Salle de cours - BGU</source>
         <comment>66</comment>
         <translatorcomment>B-Garden- Classroom</translatorcomment>
         <translation>Ｂガーデン・教室</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Cafétéria - BGU</source>
         <comment>67</comment>
         <translatorcomment>B-Garden- Cafeteria</translatorcomment>
         <translation>Ｂガーデン・学生食堂</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Niveau MD - BGU</source>
         <comment>68</comment>
         <translatorcomment>B-Garden- MD Level</translatorcomment>
         <translation>Ｂガーデン・ＭＤ層</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Hall 1er étage - BGU</source>
         <comment>69</comment>
         <translatorcomment>B-Garden- 2F Hallway</translatorcomment>
         <translation>Ｂガーデン・２階ろうか</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Hall - BGU</source>
         <comment>70</comment>
         <translatorcomment>B-Garden- Hall</translatorcomment>
         <translation>Ｂガーデン・ホール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Infirmerie - BGU</source>
         <comment>71</comment>
         <translatorcomment>B-Garden- Infirmary</translatorcomment>
         <translation>Ｂガーデン・保健室</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Dortoirs doubles - BGU</source>
         <comment>72</comment>
         <translatorcomment>B-Garden- Dormitory Double</translatorcomment>
         <translation>Ｂガーデン・学生寮大部屋</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Dortoirs simples - BGU</source>
         <comment>73</comment>
         <translatorcomment>B-Garden- Dormitory Single</translatorcomment>
         <translation>Ｂガーデン・学生寮個室</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Bureau proviseur - BGU</source>
         <comment>74</comment>
         <translatorcomment>B-Garden- Headmaster&apos;s Office</translatorcomment>
         <translation>Ｂガーデン・学園長室</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Parking - BGU</source>
         <comment>75</comment>
         <translatorcomment>B-Garden- Parking Lot</translatorcomment>
         <translation>Ｂガーデン・駐車場</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Salle de bal - BGU</source>
         <comment>76</comment>
         <translatorcomment>B-Garden- Ballroom</translatorcomment>
         <translation>Ｂガーデン・パーティ会場</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Campus - BGU</source>
         <comment>77</comment>
         <translatorcomment>B-Garden- Quad</translatorcomment>
         <translation>Ｂガーデン・校庭</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Serre de combat - BGU</source>
         <comment>78</comment>
         <translatorcomment>B-Garden- Training Center</translatorcomment>
         <translation>Ｂガーデン・訓練施設</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="125"/>
+        <location filename="Data.cpp" line="126"/>
         <source>Zone secrète - BGU</source>
         <comment>79</comment>
         <translatorcomment>B-Garden- Secret Area</translatorcomment>
         <translation>Ｂガーデン・秘密の場所</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Corridor - BGU</source>
         <comment>80</comment>
         <translatorcomment>B-Garden- Hallway</translatorcomment>
         <translation>Ｂガーデン・ろうか</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Temple - BGU</source>
         <comment>81</comment>
         <translatorcomment>B-Garden- Master Room</translatorcomment>
         <translation>Ｂガーデン・マスタールーム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Pont - BGU</source>
         <comment>82</comment>
         <translatorcomment>B-Garden- Deck</translatorcomment>
         <translation>Ｂガーデン・デッキ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Villa Dincht - Balamb</source>
         <comment>83</comment>
         <translatorcomment>Balamb- The Dincht&apos;s</translatorcomment>
         <translation>バラム・ディン邸</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Hôtel - Balamb</source>
         <comment>84</comment>
         <translatorcomment>Balamb Hotel</translatorcomment>
         <translation>バラム・ホテル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Place centrale - Balamb</source>
         <comment>85</comment>
         <translatorcomment>Balamb- Town Square</translatorcomment>
         <translation>バラム・市街</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Place de la gare - Balamb</source>
         <comment>86</comment>
         <translatorcomment>Balamb- Station Yard</translatorcomment>
         <translation>バラム・駅構内</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Port - Balamb</source>
         <comment>87</comment>
         <translatorcomment>Balamb Harbor</translatorcomment>
         <translation>バラム・港</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Résidence - Balamb</source>
         <comment>88</comment>
         <translatorcomment>Balamb- Residence</translatorcomment>
         <translation>バラム・民家</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Train</source>
         <comment>89</comment>
         <translatorcomment>Train</translatorcomment>
         <translation>列車内</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Voiture</source>
         <comment>90</comment>
         <translatorcomment>Car</translatorcomment>
         <translation>車内</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Vaisseau</source>
         <comment>91</comment>
         <translatorcomment>Inside Ship</translatorcomment>
         <translation>上陸艇内</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Mine de souffre</source>
         <comment>92</comment>
         <translatorcomment>Fire Cavern</translatorcomment>
         <translation>炎の洞窟</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Place du village - Dollet</source>
         <comment>93</comment>
         <translatorcomment>Dollet- Town Square</translatorcomment>
         <translation>ドール・市街</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Zuma Beach</source>
         <comment>94</comment>
         <translatorcomment>Dollet- Lapin Beach</translatorcomment>
         <translation>ドール・ルプタンビーチ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="126"/>
+        <location filename="Data.cpp" line="127"/>
         <source>Port - Dollet</source>
         <comment>95</comment>
         <translatorcomment>Dollet Harbor</translatorcomment>
         <translation>ドール・港</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Pub - Dollet</source>
         <comment>96</comment>
         <translatorcomment>Dollet Pub</translatorcomment>
         <translation>ドール・パブ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Hôtel - Dollet</source>
         <comment>97</comment>
         <translatorcomment>Dollet Hotel</translatorcomment>
         <translation>ドール・ホテル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Résidence - Dollet</source>
         <comment>98</comment>
         <translatorcomment>Dollet- Residence</translatorcomment>
         <translation>ドール・民家</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Tour satellite - Dollet</source>
         <comment>99</comment>
         <translatorcomment>Dollet- Comm Tower</translatorcomment>
         <translation>ドール・電波塔</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Refuge montagneux - Dollet</source>
         <comment>100</comment>
         <translatorcomment>Dollet- Mountain Hideout</translatorcomment>
         <translation>ドール・山間部</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Centre ville - Timber</source>
         <comment>101</comment>
         <translatorcomment>Timber- City Square</translatorcomment>
         <translation>ティンバー・市街</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Chaîne de TV - Timber</source>
         <comment>102</comment>
         <translatorcomment>Timber TV Station</translatorcomment>
         <translation>ティンバー・ＴＶ局</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Base des Hiboux - Timber</source>
         <comment>103</comment>
         <translatorcomment>Timber- Forest Owls&apos; Base</translatorcomment>
         <translation>ティンバー・森のフクロウアジト</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Pub - Timber</source>
         <comment>104</comment>
         <translatorcomment>Timber Pub</translatorcomment>
         <translation>ティンバー・パブ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Hôtel - Timber</source>
         <comment>105</comment>
         <translatorcomment>Timber Hotel</translatorcomment>
         <translation>ティンバー・ホテル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Train - Timber</source>
         <comment>106</comment>
         <translatorcomment>Timber- Train</translatorcomment>
         <translation>ティンバー・列車</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Résidence - Timber</source>
         <comment>107</comment>
         <translatorcomment>Timber- Residence</translatorcomment>
         <translation>ティンバー・民家</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Ecran géant - Timber</source>
         <comment>108</comment>
         <translatorcomment>Timber- TV Screen</translatorcomment>
         <translation>ティンバー・ＴＶ画面</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Centre de presse - Timber</source>
         <comment>109</comment>
         <translatorcomment>Timber- Editorial Department</translatorcomment>
         <translation>ティンバー・編集部</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Forêt de Timber</source>
         <comment>110</comment>
         <translatorcomment>Timber Forest</translatorcomment>
         <translation>ティンバーの森</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="127"/>
+        <location filename="Data.cpp" line="128"/>
         <source>Entrée - Fac de Galbadia</source>
         <comment>111</comment>
         <translatorcomment>Galbadia Garden- Front Gate</translatorcomment>
         <translation>ガルバディアガーデン・正門</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Station Fac de Galbadia</source>
         <comment>112</comment>
         <translatorcomment>G-Garden- Station</translatorcomment>
         <translation>Ｇガーデン・駅</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Hall - Fac de Galbadia</source>
         <comment>113</comment>
         <translatorcomment>G-Garden- Hall</translatorcomment>
         <translation>Ｇガーデン・ホール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Corridor - Fac de Galbadia</source>
         <comment>114</comment>
         <translatorcomment>G-Garden- Hallway</translatorcomment>
         <translation>Ｇガーデン・ろうか</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Salle d&apos;attente - Fac Galbadia</source>
         <comment>115</comment>
         <translatorcomment>G-Garden- Reception Room</translatorcomment>
         <translation>Ｇガーデン・応接室</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Salle de cours - Fac Galbadia</source>
         <comment>116</comment>
         <translatorcomment>G-Garden- Classroom</translatorcomment>
         <translation>Ｇガーデン・教室</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Salle de réunion - Fac Galbadia</source>
         <comment>117</comment>
         <translatorcomment>G-Garden- Clubroom</translatorcomment>
         <translation>Ｇガーデン・部室</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Dortoirs - Fac de Galbadia</source>
         <comment>118</comment>
         <translatorcomment>G-Garden- Dormitory</translatorcomment>
         <translation>Ｇガーデン・学生寮</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Ascenseur - Fac de Galbadia</source>
         <comment>119</comment>
         <translatorcomment>G-Garden- Elevator Hall</translatorcomment>
         <translation>Ｇガーデン・エレベーターホール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Salle recteur - Fac Galbadia</source>
         <comment>120</comment>
         <translatorcomment>G-Garden- Master Room</translatorcomment>
         <translation>Ｇガーデン・マスタールーム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Auditorium - Fac de Galbadia</source>
         <comment>121</comment>
         <translatorcomment>G-Garden- Auditorium</translatorcomment>
         <translation>Ｇガーデン・大講堂</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Stade - Fac de Galbadia</source>
         <comment>122</comment>
         <translatorcomment>G-Garden- Athletic Track</translatorcomment>
         <translation>Ｇガーデン・グラウンド</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Stand - Fac de Galbadia</source>
         <comment>123</comment>
         <translatorcomment>G-Garden- Stand</translatorcomment>
         <translation>Ｇガーデン・スタンド</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>2nde entrée - Fac Galbadia</source>
         <comment>124</comment>
         <translatorcomment>G-Garden- Back Entrance</translatorcomment>
         <translation>Ｇガーデン・裏口</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Gymnase - Fac de Galbadia</source>
         <comment>125</comment>
         <translatorcomment>G-Garden- Gymnasium</translatorcomment>
         <translation>Ｇガーデン・体育館</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Palais président - Deling City</source>
         <comment>126</comment>
         <translatorcomment>Deling- Presidential Residence</translatorcomment>
         <translation>デリングシティ・大統領官邸</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="128"/>
+        <location filename="Data.cpp" line="129"/>
         <source>Manoir Caraway - Deling City</source>
         <comment>127</comment>
         <translatorcomment>Deling City- Caraway&apos;s Mansion</translatorcomment>
         <translation>デリングシティ・カーウェイ邸</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Gare - Deling City</source>
         <comment>128</comment>
         <translatorcomment>Deling City- Station Yard</translatorcomment>
         <translation>デリングシティ・駅構内</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Place centrale - Deling City</source>
         <comment>129</comment>
         <translatorcomment>Deling City- City Square</translatorcomment>
         <translation>デリングシティ・市街</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Hôtel - Deling City</source>
         <comment>130</comment>
         <translatorcomment>Deling City- Hotel</translatorcomment>
         <translation>デリングシティ・ホテル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Bar - Deling City</source>
         <comment>131</comment>
         <translatorcomment>Deling City- Club</translatorcomment>
         <translation>デリングシティ・クラブ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Sortie - Deling City</source>
         <comment>132</comment>
         <translatorcomment>Deling City- Gateway</translatorcomment>
         <translation>デリングシティ・凱旋門</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Parade - Deling City</source>
         <comment>133</comment>
         <translatorcomment>Deling City- Parade</translatorcomment>
         <translation>デリングシティ・パレード</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Egout - Deling City</source>
         <comment>134</comment>
         <translatorcomment>Deling City- Sewer</translatorcomment>
         <translation>デリングシティ・地下水路</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Prison du désert - Galbadia</source>
         <comment>135</comment>
         <translatorcomment>Galbadia D-District Prison</translatorcomment>
         <translation>ガルバディアＤ地区収容所</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Désert</source>
         <comment>136</comment>
         <translatorcomment>Desert</translatorcomment>
         <translation>砂漠</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Base des missiles</source>
         <comment>137</comment>
         <translatorcomment>Galbadia Missile Base</translatorcomment>
         <translation>ガルバディア軍ミサイル基地</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Village de Winhill</source>
         <comment>138</comment>
         <translatorcomment>Winhill Village</translatorcomment>
         <translation>ウィンヒル・村</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Pub - Winhill</source>
         <comment>139</comment>
         <translatorcomment>Winhill Pub</translatorcomment>
         <translation>ウィンヒル・パブ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Maison vide - Winhill</source>
         <comment>140</comment>
         <translatorcomment>Winhill- Vacant House</translatorcomment>
         <translation>ウィンヒル・空き家</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Manoir - Winhill</source>
         <comment>141</comment>
         <translatorcomment>Winhill- Mansion</translatorcomment>
         <translation>ウィンヒル・やしき</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Résidence - Winhill</source>
         <comment>142</comment>
         <translatorcomment>Winhill- Residence</translatorcomment>
         <translation>ウィンヒル・民家</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="129"/>
+        <location filename="Data.cpp" line="130"/>
         <source>Hôtel - Winhill</source>
         <comment>143</comment>
         <translatorcomment>Winhill- Hotel</translatorcomment>
         <translation>ウィンヒル・ホテル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Voiture - Winhill</source>
         <comment>144</comment>
         <translatorcomment>Winhill- Car</translatorcomment>
         <translation>ウィンヒル・車内</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Tombe du roi inconnu</source>
         <comment>145</comment>
         <translatorcomment>Tomb of the Unknown King</translatorcomment>
         <translation>名もなき王の墓</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Horizon</source>
         <comment>146</comment>
         <translatorcomment>Fishermans Horizon</translatorcomment>
         <translation>フィッシャーマンズ・ホライズン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Habitations - Horizon</source>
         <comment>147</comment>
         <translatorcomment>FH- Residential Area</translatorcomment>
         <translation>Ｆ．Ｈ．・居住区</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Ecrans solaires - Horizon</source>
         <comment>148</comment>
         <translatorcomment>FH- Sun Panel</translatorcomment>
         <translation>Ｆ．Ｈ．・ミラーパネル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Villa du maire - Horizon</source>
         <comment>149</comment>
         <translatorcomment>FH- Mayor&apos;s Residence</translatorcomment>
         <translation>Ｆ．Ｈ．・駅長邸</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Usine - Horizon</source>
         <comment>150</comment>
         <translatorcomment>FH- Factory</translatorcomment>
         <translation>Ｆ．Ｈ．・工場</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Salle des fêtes - Horizon</source>
         <comment>151</comment>
         <translatorcomment>FH- Festival Grounds</translatorcomment>
         <translation>Ｆ．Ｈ．・学園祭会場</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Hôtel - Horizon</source>
         <comment>152</comment>
         <translatorcomment>FH- Hotel</translatorcomment>
         <translation>Ｆ．Ｈ．・ホテル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Résidence - Horizon</source>
         <comment>153</comment>
         <translatorcomment>FH- Residence</translatorcomment>
         <translation>Ｆ．Ｈ．・民家</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Gare - Horizon</source>
         <comment>154</comment>
         <translatorcomment>FH- Station Yard</translatorcomment>
         <translation>Ｆ．Ｈ．・駅構内</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Aqueduc d&apos;Horizon</source>
         <comment>155</comment>
         <translatorcomment>FH- Horizon Bridge</translatorcomment>
         <translation>ホライズン・ブリッジ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Station balnéaire</source>
         <comment>156</comment>
         <translatorcomment>FH- Seaside Station</translatorcomment>
         <translation>海岸駅</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Salt Lake</source>
         <comment>157</comment>
-        <translatorcomment>FH- Geat Salt Lake</translatorcomment>
+        <translatorcomment>FH- Great Salt Lake</translatorcomment>
         <translation>大塩湖</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Bâtiment mystérieux</source>
         <comment>158</comment>
         <translatorcomment>FH- Mystery Building</translatorcomment>
         <translation>なぞの建造物</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="130"/>
+        <location filename="Data.cpp" line="131"/>
         <source>Esthar City</source>
         <comment>159</comment>
         <translatorcomment>Esthar- City</translatorcomment>
         <translation>エスタ・市街</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Laboratoire Geyser - Esthar</source>
         <comment>160</comment>
         <translatorcomment>Esthar- Odine&apos;s Laboratory</translatorcomment>
         <translation>エスタ・オダイン博士の研究所</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Aérodrome - Esthar</source>
         <comment>161</comment>
         <translatorcomment>Esthar- Airstation</translatorcomment>
         <translation>エスタ・エアステーション</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Lunatic Pandora approche</source>
         <comment>162</comment>
         <translatorcomment>Lunatic Pandora Approaching</translatorcomment>
         <translation>エスタ・大石柱接近</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Résidence président - Esthar</source>
         <comment>163</comment>
         <translatorcomment>Esthar- Presidential Palace</translatorcomment>
         <translation>エスタ・大統領官邸</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Hall - Résidence président</source>
         <comment>164</comment>
         <translatorcomment>Presidential Palace- Hall</translatorcomment>
         <translation>大統領官邸・ホール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Couloir - Résidence président</source>
         <comment>165</comment>
         <translatorcomment>Presidential Palace- Hallway</translatorcomment>
         <translation>大統領官邸・ろうか</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Bureau - Résidence président</source>
         <comment>166</comment>
         <translatorcomment>Presidential Palace- Office</translatorcomment>
         <translation>大統領官邸・大統領の部屋</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Accueil - Labo Geyser</source>
         <comment>167</comment>
         <translatorcomment>Dr. Odine&apos;s Laboratory- Lobby</translatorcomment>
         <translation>オダイン博士の研究所・ロビー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Laboratoire Geyser</source>
         <comment>168</comment>
         <translatorcomment>Dr. Odine&apos;s Laboratory- Lab</translatorcomment>
         <translation>オダイン博士の研究所・研究室</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Deleted</source>
         <comment>169</comment>
         <translatorcomment>Deleted 内部にあるだけ？</translatorcomment>
         <translation>さくじょされました</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Lunar Gate</source>
         <comment>170</comment>
         <translatorcomment>Lunar Gate</translatorcomment>
         <translation>ルナゲート</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Parvis - Lunar Gate</source>
         <comment>171</comment>
         <translatorcomment>Lunar Gate- Concourse</translatorcomment>
         <translation>ルナゲート・コンコース</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Glacière - Lunar gate</source>
         <comment>172</comment>
         <translatorcomment>Lunar Gate- Deep Freeze</translatorcomment>
         <translation>ルナゲート・フリージングルーム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Mausolée - Esthar</source>
         <comment>173</comment>
         <translatorcomment>Esthar Sorceress Memorial</translatorcomment>
         <translation>エスタ国立魔女記念館</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Entrée - Mausolée</source>
         <comment>174</comment>
         <translatorcomment>Sorceress Memorial- Entrance</translatorcomment>
         <translation>エスタ国立魔女記念館・入口</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="131"/>
+        <location filename="Data.cpp" line="132"/>
         <source>Pod de confinement - Mausolée</source>
         <comment>175</comment>
         <translatorcomment>Sorceress Memorial- Pod</translatorcomment>
         <translation>エスタ国立魔女記念館・ポッド</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Salle de contrôle - Mausolée</source>
         <comment>176</comment>
         <translatorcomment>Sorceress Memorial- Ctrl Room</translatorcomment>
         <translation>エスタ国立魔女記念館・制御室</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Tears Point</source>
         <comment>177</comment>
         <translatorcomment>Tears&apos; Point</translatorcomment>
         <translation>ティアーズポイント</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Labo Lunatic Pandora</source>
         <comment>178</comment>
         <translatorcomment>Lunatic Pandora Laboratory</translatorcomment>
         <translation>ルナティックパンドラ研究所</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Zone d&apos;atterrissage de secours</source>
         <comment>179</comment>
         <translatorcomment>Emergency Landing Zone</translatorcomment>
         <translation>不時着地点</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Zone d&apos;atterrissage officielle</source>
         <comment>180</comment>
         <translatorcomment>Spaceship Landing Zone</translatorcomment>
         <translation>飛空艇不時着地点</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Lunatic Pandora</source>
         <comment>181</comment>
         <translatorcomment>Lunatic Pandora</translatorcomment>
         <translation>ルナティックパンドラ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Site des fouilles - Centra</source>
         <comment>182</comment>
         <translatorcomment>Centra- Excavation Site</translatorcomment>
         <translation>セントラ・発掘現場</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Orphelinat</source>
         <comment>183</comment>
         <translatorcomment>Edea&apos;s House</translatorcomment>
         <translation>イデアの家</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Salle de jeux - Orphelinat</source>
         <comment>184</comment>
         <translatorcomment>Edea&apos;s House- Playroom</translatorcomment>
         <translation>イデアの家・こども部屋</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Dortoir - Orphelinat</source>
         <comment>185</comment>
         <translatorcomment>Edea&apos;s House- Bedroom</translatorcomment>
         <translation>イデアの家・イデアの部屋</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Jardin - Orphelinat</source>
         <comment>186</comment>
         <translatorcomment>Edea&apos;s House- Backyard</translatorcomment>
         <translation>イデアの家・裏庭</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Front de mer - Orphelinat</source>
         <comment>187</comment>
         <translatorcomment>Edea&apos;s House- Oceanside</translatorcomment>
         <translation>イデアの家・海岸</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Champ - Orphelinat</source>
         <comment>188</comment>
         <translatorcomment>Edea&apos;s House- Flower Field</translatorcomment>
         <translation>イデアの家・花畑</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Ruines de Centra</source>
         <comment>189</comment>
         <translatorcomment>Centra Ruins</translatorcomment>
         <translation>セントラ遺跡</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Entrée - Fac de Trabia</source>
         <comment>190</comment>
         <translatorcomment>Trabia Garden- Front Gate</translatorcomment>
         <translation>トラビアガーデン・正門</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="132"/>
+        <location filename="Data.cpp" line="133"/>
         <source>Cimetière - Fac de Trabia</source>
         <comment>191</comment>
         <translatorcomment>T-Garden- Cemetery</translatorcomment>
         <translation>Ｔガーデン・墓地</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Garage - Fac de Trabia</source>
         <comment>192</comment>
         <translatorcomment>T-Garden- Garage</translatorcomment>
         <translation>Ｔガーデン・ガレージ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Campus - Fac Trabia</source>
         <comment>193</comment>
         <translatorcomment>T-Garden- Festival Stage</translatorcomment>
         <translation>Ｔガーデン・学園祭ステージ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Amphithéatre - Fac de Trabia</source>
         <comment>194</comment>
         <translatorcomment>T-Garden- Classroom</translatorcomment>
         <translation>Ｔガーデン・教室</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Stade - Fac de Trabia</source>
         <comment>195</comment>
         <translatorcomment>T-Garden- Athletic Ground</translatorcomment>
         <translation>Ｔガーデン・グラウンド</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Dôme mystérieux</source>
         <comment>196</comment>
         <translatorcomment>Mystery Dome</translatorcomment>
         <translation>なぞのドーム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Ville du désert - Shumi Village</source>
         <comment>197</comment>
         <translatorcomment>Shumi Village- Desert Village</translatorcomment>
         <translation>シュミ族の村・砂漠化村</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Ascenseur - Shumi Village</source>
         <comment>198</comment>
         <translatorcomment>Shumi Village- Elevator</translatorcomment>
         <translation>シュミ族の村・エレベーター</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Shumi Village</source>
         <comment>199</comment>
         <translatorcomment>Shumi Village- Village</translatorcomment>
         <translation>シュミ族の村・村</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Habitation - Shumi Village</source>
         <comment>200</comment>
         <translatorcomment>Shumi Village- Residence</translatorcomment>
         <translation>シュミ族の村・民家</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Résidence - Shumi Village</source>
         <comment>201</comment>
         <translatorcomment>Shumi Village- Residence</translatorcomment>
         <translation>シュミ族の村・民家</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Habitat - Shumi Village</source>
         <comment>202</comment>
         <translatorcomment>Shumi Village- Residence</translatorcomment>
         <translation>シュミ族の村・民家</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Hôtel - Shumi Village</source>
         <comment>203</comment>
         <translatorcomment>Shumi Village- Hotel</translatorcomment>
         <translation>シュミ族の村・ホテル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Trabia canyon</source>
         <comment>204</comment>
         <translatorcomment>Trabia Canyon</translatorcomment>
         <translation>トラビア渓谷</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Vaisseau des Seeds blancs</source>
         <comment>205</comment>
         <translatorcomment>White SeeD Ship</translatorcomment>
         <translation>白いＳｅｅＤの船</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Navire des Seeds Blancs</source>
         <comment>206</comment>
         <translatorcomment>White SeeD Ship</translatorcomment>
         <translation>白いＳｅｅＤの船</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="133"/>
+        <location filename="Data.cpp" line="134"/>
         <source>Cabine - Navire Seeds blancs</source>
         <comment>207</comment>
         <translatorcomment>White SeeD Ship- Cabin</translatorcomment>
         <translation>白いＳｅｅＤの船・キャビン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Cockpit - Hydre</source>
         <comment>208</comment>
         <translatorcomment>Ragnarok- Cockpit</translatorcomment>
         <translation>飛空艇ラグナロク・コクピット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Siège passager - Hydre</source>
         <comment>209</comment>
         <translatorcomment>Ragnarok- Passenger Seat</translatorcomment>
         <translation>飛空艇ラグナロク・客席</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Couloir - Hydre</source>
         <comment>210</comment>
         <translatorcomment>Ragnarok- Aisle</translatorcomment>
         <translation>飛空艇ラグナロク・通路</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Hangar - Hydre</source>
         <comment>211</comment>
         <translatorcomment>Ragnarok- Hangar</translatorcomment>
         <translation>飛空艇ラグナロク・ハンガー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Accès - Hydre</source>
         <comment>212</comment>
         <translatorcomment>Ragnarok- Entrance</translatorcomment>
         <translation>飛空艇ラグナロク・乗降口</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Air Room - Hydre</source>
         <comment>213</comment>
         <translatorcomment>Ragnarok- Air Room</translatorcomment>
         <translation>飛空艇ラグナロク・エアールーム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Salle de pression - Hydre</source>
         <comment>214</comment>
         <translatorcomment>Ragnarok- Space Hatch</translatorcomment>
         <translation>飛空艇ラグナロク・宇宙用ハッチ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Centre de recherches Deep Sea</source>
         <comment>215</comment>
         <translatorcomment>Deep Sea Research Center</translatorcomment>
         <translation>海洋探査人工島</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Laboratoire - Deep Sea</source>
         <comment>216</comment>
         <translatorcomment>Deep Sea Research Center- Lb</translatorcomment>
         <translation>海洋探査人工島・研究所</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Salle de travail - Deep Sea</source>
         <comment>217</comment>
         <translatorcomment>Deep Sea Research Center- Lv</translatorcomment>
         <translation>海洋探査人工島・作業区</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Fouilles - Deep Sea</source>
         <comment>218</comment>
         <translatorcomment>Deep Sea Deposit</translatorcomment>
         <translation>大海のよどみ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Salle de contrôle - Base lunaire</source>
         <comment>219</comment>
         <translatorcomment>Lunar Base- Control Room</translatorcomment>
         <translation>ルナサイドベース・制御室</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Centre médical - Base lunaire</source>
         <comment>220</comment>
         <translatorcomment>Lunar Base- Medical Room</translatorcomment>
         <translation>ルナサイドベース・医務室</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Pod - Base lunaire</source>
         <comment>221</comment>
         <translatorcomment>Lunar Base- Pod</translatorcomment>
         <translation>ルナサイドベース・ポッド</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Dock - Base lunaire</source>
         <comment>222</comment>
         <translatorcomment>Lunar Base- Dock</translatorcomment>
         <translation>ルナサイドベース・ドック</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="134"/>
+        <location filename="Data.cpp" line="135"/>
         <source>Passage - Base lunaire</source>
         <comment>223</comment>
         <translatorcomment>Lunar Base- Passageway</translatorcomment>
         <translation>ルナサイドベース・通路</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Vestiaire - Base lunaire</source>
         <comment>224</comment>
         <translatorcomment>Lunar Base- Locker</translatorcomment>
         <translation>ルナサイドベース・ロッカー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Habitats - Base lunaire</source>
         <comment>225</comment>
         <translatorcomment>Lunar Base- Residential Zone</translatorcomment>
         <translation>ルナサイドベース・居住区</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Hyper Espace</source>
         <comment>226</comment>
         <translatorcomment>Outer Space</translatorcomment>
         <translation>宇宙空間</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Forêt Chocobo</source>
         <comment>227</comment>
         <translatorcomment>Chocobo Forest</translatorcomment>
         <translation>チョコボの森</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Jungle</source>
         <comment>228</comment>
         <translatorcomment>Wilderness</translatorcomment>
         <translation>荒野</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Citadelle d&apos;Ultimecia - Vestibule</source>
         <comment>229</comment>
         <translatorcomment>Ultimecia Castle- Hall</translatorcomment>
         <translation>アルティミシア城・ホール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Citadelle d&apos;Ultimecia - Hall</source>
         <comment>230</comment>
         <translatorcomment>Ultimecia Castle- Grand Hall</translatorcomment>
         <translation>アルティミシア城・大広間</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Citadelle d&apos;Ultimecia - Terrasse</source>
         <comment>231</comment>
         <translatorcomment>Ultimecia Castle- Terrace</translatorcomment>
         <translation>アルティミシア城・テラス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Citadelle d&apos;Ultimecia - Cave</source>
         <comment>232</comment>
         <translatorcomment>Ultimecia Castle- Wine Cellar</translatorcomment>
         <translation>アルティミシア城・ワインセラー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Citadelle d&apos;Ultimecia - Couloir</source>
         <comment>233</comment>
         <translatorcomment>Ultimecia Castle- Passageway</translatorcomment>
         <translation>アルティミシア城・通路</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Elévateur - Citadelle</source>
         <comment>234</comment>
         <translatorcomment>Ultimecia Castle- Elevator Hall</translatorcomment>
         <translation>アルティミシア城・昇降機ホール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Escalier - Citadelle d&apos;Ultimecia</source>
         <comment>235</comment>
         <translatorcomment>Ultimecia Castle- Stairway Hall</translatorcomment>
         <translation>アルティミシア城・階段ホール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Salle du trésor - Citadelle</source>
         <comment>236</comment>
         <translatorcomment>Ultimecia Castle- Treasure Rm</translatorcomment>
         <translation>アルティミシア城・宝物庫</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Salle de rangement - Citadelle</source>
         <comment>237</comment>
         <translatorcomment>Ultimecia Castle- Storage Room</translatorcomment>
         <translation>アルティミシア城・倉庫</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Citadelle d&apos;Ultimecia - Galerie</source>
         <comment>238</comment>
         <translatorcomment>Ultimecia Castle- Art Gallery</translatorcomment>
         <translation>アルティミシア城・画廊</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="135"/>
+        <location filename="Data.cpp" line="136"/>
         <source>Citadelle d&apos;Ultimecia - Ecluse</source>
         <comment>239</comment>
         <translatorcomment>Ultimecia Castle- Flood Gate</translatorcomment>
         <translation>アルティミシア城・水門</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Citadelle - Armurerie</source>
         <comment>240</comment>
         <translatorcomment>Ultimecia Castle- Armory</translatorcomment>
         <translation>アルティミシア城・武器庫</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Citadelle d&apos;Ultimecia - Prison</source>
         <comment>241</comment>
         <translatorcomment>Ultimecia Castle- Prison Cell</translatorcomment>
         <translation>アルティミシア城・牢獄</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Citadelle d&apos;Ultimecia - Fossé</source>
         <comment>242</comment>
         <translatorcomment>Ultimecia Castle- Waterway</translatorcomment>
         <translation>アルティミシア城・水路</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Citadelle d&apos;Ultimecia - Jardin</source>
         <comment>243</comment>
         <translatorcomment>Ultimecia Castle- Courtyard</translatorcomment>
         <translation>アルティミシア城・中庭</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Citadelle d&apos;Ultimecia - Chapelle</source>
         <comment>244</comment>
         <translatorcomment>Ultimecia Castle- Chapel</translatorcomment>
         <translation>アルティミシア城・礼拝堂</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Clocher - Citadelle d&apos;Ultimecia</source>
         <comment>245</comment>
         <translatorcomment>Ultimecia Castle- Clock Tower</translatorcomment>
         <translation>アルティミシア城・時計塔</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Chambre d&apos;Ultimecia - Citadelle</source>
         <comment>246</comment>
         <translatorcomment>Ultimecia Castle- Master Room</translatorcomment>
         <translation>アルティミシア城・主の間</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Citadelle d&apos;Ultimecia</source>
         <comment>248</comment>
         <translatorcomment>Ultimecia Castle</translatorcomment>
         <translation>アルティミシア城</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Salle d&apos;initiation</source>
         <comment>249</comment>
         <translatorcomment>Commencement Room</translatorcomment>
         <translation>はじまりの部屋</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="136"/>
+        <location filename="Data.cpp" line="137"/>
         <source>Reine des cartes</source>
         <comment>250</comment>
         <translatorcomment>Queen</translatorcomment>
         <translation>クィーン</translation>
     </message>
     <message>
+        <location filename="Data.cpp" line="142"/>
+        <source>Balamb City</source>
+        <translation>バラム</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="142"/>
+        <source>Deling City</source>
+        <translation>デリングシティ</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="142"/>
+        <source>Shumi Village</source>
+        <translation type="unfinished">シュミ族の村</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="143"/>
+        <source>Winhill</source>
+        <translation>ウィンヒル</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="143"/>
+        <source>Dollet</source>
+        <translation>ドール</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="143"/>
+        <source>Horizon</source>
+        <translation>Ｆ．Ｈ．</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="144"/>
+        <source>Lunar Gate</source>
+        <translation type="unfinished">ルナゲート</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="144"/>
+        <source>Esthar City</source>
+        <translation type="unfinished">エスタシティ</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="144"/>
+        <source>Timber</source>
+        <translation type="unfinished">パブ</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="145"/>
+        <source>BGU</source>
+        <translation type="unfinished">バラムガーデン</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="145"/>
+        <source>GGU</source>
+        <translation type="unfinished">ガルバディアガーデン</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="145"/>
+        <source>TGU</source>
+        <translation type="unfinished">トラビア</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="145"/>
+        <source>Ruines de Centra</source>
+        <translation type="unfinished">セントラ遺跡</translation>
+    </message>
+    <message>
         <location filename="Data.cpp" line="146"/>
+        <source>Orphelinat</source>
+        <translation type="unfinished">イデアの家</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="146"/>
+        <source>Salt Lake</source>
+        <translation type="unfinished">大塩湖</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="146"/>
+        <source>Forêt des novices</source>
+        <translation type="unfinished">チョコボの森</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="147"/>
+        <source>Forêt Classica</source>
+        <translation type="unfinished">チョコボの森</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="147"/>
+        <source>Forêt de l&apos;errance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="147"/>
+        <source>Sanctuaire des chocobos</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="148"/>
+        <source>Forêt clôturée</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="148"/>
+        <source>Forêt fun</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="148"/>
+        <source>Forêt de la solitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="149"/>
+        <source>Pod de secours</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="159"/>
         <source>Sagaie</source>
         <translatorcomment>Strange Vision</translatorcomment>
         <translation>ゆめかまぼろしか</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="154"/>
+        <location filename="Data.cpp" line="167"/>
         <source>Boko</source>
         <translatorcomment>Boko</translatorcomment>
         <translation>コチョコボ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="167"/>
+        <location filename="Data.cpp" line="180"/>
         <source>Feinte</source>
         <translatorcomment>Booya</translatorcomment>
         <translation>ヘッドショック</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="167"/>
+        <location filename="Data.cpp" line="180"/>
         <source>Achille</source>
         <translatorcomment>Heel Drop</translatorcomment>
         <translation>かかと落とし</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="167"/>
+        <location filename="Data.cpp" line="180"/>
         <source>Forcing</source>
         <translatorcomment>Mach Kick</translatorcomment>
         <translation>マッハキック</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="167"/>
+        <location filename="Data.cpp" line="180"/>
         <source>Delphinium</source>
         <translatorcomment>Dolphin Blow</translatorcomment>
         <translation>ドルフィンブロウ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="168"/>
+        <location filename="Data.cpp" line="181"/>
         <source>Apesanteur</source>
         <translatorcomment>Meteor Strike</translatorcomment>
         <translation>メテオストライク</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="168"/>
+        <location filename="Data.cpp" line="181"/>
         <source>Fahreinheit</source>
         <translatorcomment>Burning Rave</translatorcomment>
         <translation>バーニングレイヴ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="168"/>
+        <location filename="Data.cpp" line="181"/>
         <source>Stratosphère</source>
         <translatorcomment>Meteor Barret</translatorcomment>
         <translation>メテオバレット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="168"/>
+        <location filename="Data.cpp" line="181"/>
         <source>Trapèze</source>
         <translatorcomment>Different Beat</translatorcomment>
         <translation>ディファレントビート</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="168"/>
+        <location filename="Data.cpp" line="181"/>
         <source>Global Wave</source>
         <translatorcomment>My Final Heaven</translatorcomment>
         <translation>俺式ファイナルヘヴン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="173"/>
+        <location filename="Data.cpp" line="186"/>
         <source>Furioso</source>
         <translatorcomment>Normal Shot</translatorcomment>
         <translation>ノーマルショット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="173"/>
+        <location filename="Data.cpp" line="186"/>
         <source>Fluxion</source>
         <translatorcomment>Scatter Shot</translatorcomment>
         <translation>グレープショット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="173"/>
+        <location filename="Data.cpp" line="186"/>
         <source>Fracas</source>
         <translatorcomment>Dark Shot</translatorcomment>
         <translation>ダークショット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="173"/>
+        <location filename="Data.cpp" line="186"/>
         <source>Fusion</source>
         <translatorcomment>Flame Shot</translatorcomment>
         <translation>フレイムショット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="174"/>
+        <location filename="Data.cpp" line="187"/>
         <source>Barbacane</source>
         <translatorcomment>Canister Shot</translatorcomment>
         <translation>キャニスターショット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="174"/>
+        <location filename="Data.cpp" line="187"/>
         <source>Mach 4</source>
         <translatorcomment>Quick Shot</translatorcomment>
         <translation>クイックショット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="174"/>
+        <location filename="Data.cpp" line="187"/>
         <source>Apogée</source>
         <translatorcomment>Armor Shot</translatorcomment>
         <translation>アーマーショット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="174"/>
+        <location filename="Data.cpp" line="187"/>
         <source>Percuteur</source>
         <translatorcomment>Hyper Shot</translatorcomment>
         <translation>ハイパーショット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="179"/>
+        <location filename="Data.cpp" line="192"/>
         <source>Fovéa</source>
         <translatorcomment>Laser Eye</translatorcomment>
         <translation>メーザーアイ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="179"/>
+        <location filename="Data.cpp" line="192"/>
         <source>Ultra Waves</source>
         <translatorcomment>Ultra Waves</translatorcomment>
         <translation>超振動</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="179"/>
+        <location filename="Data.cpp" line="192"/>
         <source>Firmament</source>
         <translatorcomment>Electrocute</translatorcomment>
         <translation>電撃</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="179"/>
+        <location filename="Data.cpp" line="192"/>
         <source>Freak</source>
         <translatorcomment>LV?Death</translatorcomment>
         <translation>LV?デス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="180"/>
+        <location filename="Data.cpp" line="193"/>
         <source>Dégénérator</source>
         <translatorcomment>Degenerator</translatorcomment>
         <translation>デジョネーター</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="180"/>
+        <location filename="Data.cpp" line="193"/>
         <source>Fréon</source>
         <translatorcomment>Aqua Breath</translatorcomment>
         <translation>アクアブレス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="180"/>
+        <location filename="Data.cpp" line="193"/>
         <source>Micro Missiles</source>
         <translatorcomment>Micro Missiles</translatorcomment>
         <translation>マイクロミサイル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="180"/>
+        <location filename="Data.cpp" line="193"/>
         <source>Acid</source>
         <translatorcomment>Acid</translatorcomment>
         <translation>溶解液</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="181"/>
+        <location filename="Data.cpp" line="194"/>
         <source>Mitraille</source>
         <translatorcomment>Gatling Gun</translatorcomment>
         <translation>ガトリング砲</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="181"/>
+        <location filename="Data.cpp" line="194"/>
         <source>Dead Heat</source>
         <translatorcomment>Fire Breath</translatorcomment>
         <translation>ファイヤーブレス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="181"/>
+        <location filename="Data.cpp" line="194"/>
         <source>Infection</source>
         <translatorcomment>Bad Breath</translatorcomment>
         <translation>くさい息</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="181"/>
+        <location filename="Data.cpp" line="194"/>
         <source>Mistral</source>
         <translatorcomment>White Wind</translatorcomment>
         <translation>ホワイトウインド</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="182"/>
+        <location filename="Data.cpp" line="195"/>
         <source>Laser</source>
         <translatorcomment>Homing Laser</translatorcomment>
         <translation>ホーミングレーザー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="182"/>
+        <location filename="Data.cpp" line="195"/>
         <source>Mother</source>
         <translatorcomment>Mighty Guard</translatorcomment>
         <translation>マイティガード</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="182"/>
+        <location filename="Data.cpp" line="195"/>
         <source>Shockwave</source>
         <translatorcomment>Ray-Bomb</translatorcomment>
         <translation>レイ・ボム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="182"/>
+        <location filename="Data.cpp" line="195"/>
         <source>Outerspace</source>
         <translatorcomment>Shockwave Pulsar</translatorcomment>
         <translation>ショックウェーブパルサー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="187"/>
+        <location filename="Data.cpp" line="200"/>
         <source>Dingo</source>
         <translatorcomment>Rush</translatorcomment>
         <translation>ラッシュ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="187"/>
+        <location filename="Data.cpp" line="200"/>
         <source>Shepherd</source>
         <translatorcomment>Recover</translatorcomment>
         <translation>リカバー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="187"/>
+        <location filename="Data.cpp" line="200"/>
         <source>Dachshund</source>
         <translatorcomment>Reverse</translatorcomment>
         <translation>リバース</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="187"/>
+        <location filename="Data.cpp" line="200"/>
         <source>Borzoï</source>
         <translatorcomment>Search</translatorcomment>
         <translation>サーチ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="188"/>
+        <location filename="Data.cpp" line="201"/>
         <source>Laïka</source>
         <translatorcomment>Cannon</translatorcomment>
         <translation>キャノン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="188"/>
+        <location filename="Data.cpp" line="201"/>
         <source>Nordfolk</source>
         <translatorcomment>Strike</translatorcomment>
         <translation>ストライク</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="188"/>
+        <location filename="Data.cpp" line="201"/>
         <source>Sélénium</source>
         <translatorcomment>Invincible Moon</translatorcomment>
         <translation>インビジブルムーン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="188"/>
+        <location filename="Data.cpp" line="201"/>
         <source>Phantasm</source>
         <translatorcomment>Wishing Star</translatorcomment>
         <translation>ウィッシュスター</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="193"/>
+        <location filename="Data.cpp" line="206"/>
         <source>Bogomile</source>
         <translatorcomment>Geezard</translatorcomment>
         <translation>ハウリザード</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="193"/>
+        <location filename="Data.cpp" line="206"/>
         <source>Fungus</source>
         <translatorcomment>Funguar</translatorcomment>
         <translation>フンゴオンゴ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="193"/>
+        <location filename="Data.cpp" line="206"/>
         <source>Elmidea</source>
         <translatorcomment>Bite Bug</translatorcomment>
         <translation>バイトバグ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="193"/>
+        <location filename="Data.cpp" line="206"/>
         <source>Nocturnus</source>
         <translatorcomment>Red Bat</translatorcomment>
         <translation>レッドマウス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="193"/>
+        <location filename="Data.cpp" line="206"/>
         <source>Incube</source>
         <translatorcomment>Blobra</translatorcomment>
         <translation>プリヌラ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="193"/>
+        <location filename="Data.cpp" line="206"/>
         <source>Aphide</source>
         <translatorcomment>Gayla</translatorcomment>
         <translation>ゲイラ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="194"/>
+        <location filename="Data.cpp" line="207"/>
         <source>Elastos</source>
         <translatorcomment>Gesper</translatorcomment>
         <translation>ゲスパー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="194"/>
+        <location filename="Data.cpp" line="207"/>
         <source>Diodon</source>
         <translatorcomment>フォカロルフェイク (カード), Fr: Diodon, En: Fastitocalon-F, 仏英正しい
 Phantom = Fastitocalon = フォカロル
@@ -7494,109 +7614,109 @@ Diodon = Fastitocalon-F = フォカロルフェイク</translatorcomment>
         <translation>フォカロルフェイク</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="194"/>
+        <location filename="Data.cpp" line="207"/>
         <source>Carnidéa</source>
         <translatorcomment>Blood Soul</translatorcomment>
         <translation>ブラットソウル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="194"/>
+        <location filename="Data.cpp" line="207"/>
         <source>Larva</source>
         <translatorcomment>Caterchipillar</translatorcomment>
         <translation>ケダチク</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="194"/>
+        <location filename="Data.cpp" line="207"/>
         <source>Gallus</source>
         <translatorcomment>Cockatrice</translatorcomment>
         <translation>コカトリス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="194"/>
+        <location filename="Data.cpp" line="207"/>
         <source>Orchida</source>
         <translatorcomment>Grat</translatorcomment>
         <translation>グラット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="195"/>
+        <location filename="Data.cpp" line="208"/>
         <source>Schizoïd</source>
         <translatorcomment>Buel</translatorcomment>
         <translation>ブエル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="195"/>
+        <location filename="Data.cpp" line="208"/>
         <source>Licorne</source>
         <translatorcomment>Mesmerize</translatorcomment>
         <translation>メズマライズ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="195"/>
+        <location filename="Data.cpp" line="208"/>
         <source>Koatl</source>
         <translatorcomment>Belhelmel</translatorcomment>
         <translation>ベルヘルメルヘル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="195"/>
+        <location filename="Data.cpp" line="208"/>
         <source>Malaku</source>
         <translatorcomment>Thrustaevis</translatorcomment>
         <translation>スラストエイビス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="195"/>
+        <location filename="Data.cpp" line="208"/>
         <source>Arconada</source>
         <translatorcomment>Anacondaur</translatorcomment>
         <translation>ヘッジヴァイパー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="195"/>
+        <location filename="Data.cpp" line="208"/>
         <source>Xylopode</source>
         <translatorcomment>Glacial Eye</translatorcomment>
         <translation>グヘイスアイ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="196"/>
+        <location filename="Data.cpp" line="209"/>
         <source>Formicide</source>
         <translatorcomment>Creeps</translatorcomment>
         <translation>クリープス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="196"/>
+        <location filename="Data.cpp" line="209"/>
         <source>Feng</source>
         <translatorcomment>Grendel</translatorcomment>
         <translation>グレンデル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="196"/>
+        <location filename="Data.cpp" line="209"/>
         <source>Héra</source>
         <translatorcomment>Jelleye</translatorcomment>
         <translation>ダブルハガー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="196"/>
+        <location filename="Data.cpp" line="209"/>
         <source>Selek</source>
         <translatorcomment>Grand Mantis</translatorcomment>
         <translation>グランデアーロ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="196"/>
+        <location filename="Data.cpp" line="209"/>
         <source>Weevil</source>
         <translatorcomment>Forbidden</translatorcomment>
         <translation>ライフフォビドン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="196"/>
+        <location filename="Data.cpp" line="209"/>
         <source>Scavenger</source>
         <translatorcomment>Armadodo</translatorcomment>
         <translation>エサンスーシ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="197"/>
+        <location filename="Data.cpp" line="210"/>
         <source>Adéphage</source>
         <translatorcomment>Tri-Face</translatorcomment>
         <translation>トライフェイス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="197"/>
+        <location filename="Data.cpp" line="210"/>
         <source>Phantom</source>
         <translatorcomment>フォカロル (カード), Fr: Phantom, En: Fastitocalon, 仏英正しい
 Phantom = Fastitocalon = フォカロル
@@ -7604,435 +7724,435 @@ Diodon = Fastitocalon-F = フォカロルフェイク</translatorcomment>
         <translation>フォカロル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="197"/>
+        <location filename="Data.cpp" line="210"/>
         <source>Satyrux</source>
         <translatorcomment>Snow Lion</translatorcomment>
         <translation>ゴージュシール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="197"/>
+        <location filename="Data.cpp" line="210"/>
         <source>Trogiidae</source>
         <translatorcomment>Ochu</translatorcomment>
         <translation>オチュー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="197"/>
+        <location filename="Data.cpp" line="210"/>
         <source>Barbarian</source>
         <translatorcomment>SAM08G</translatorcomment>
         <translation>SAM08G</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="198"/>
+        <location filename="Data.cpp" line="211"/>
         <source>Célébis</source>
         <translatorcomment>Abyss Worm</translatorcomment>
         <translation>アビスウォーム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="198"/>
+        <location filename="Data.cpp" line="211"/>
         <source>Eiffel</source>
         <translatorcomment>Turtapod</translatorcomment>
         <translation>グラナトゥム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="198"/>
+        <location filename="Data.cpp" line="211"/>
         <source>Cariatide</source>
         <translatorcomment>Vysage</translatorcomment>
         <translation>バイセージ・ハンズ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="198"/>
+        <location filename="Data.cpp" line="211"/>
         <source>Pampa</source>
         <comment>card</comment>
         <translatorcomment>Cactuar</translatorcomment>
         <translation>サボテンダー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="198"/>
+        <location filename="Data.cpp" line="211"/>
         <source>Tomberry</source>
         <comment>card</comment>
         <translatorcomment>Tonberry</translatorcomment>
         <translation>トンベリ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="198"/>
+        <location filename="Data.cpp" line="211"/>
         <source>Berserker</source>
         <translation>ワイルドフック</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="199"/>
+        <location filename="Data.cpp" line="212"/>
         <source>T-rex</source>
         <translatorcomment>T-Rexaur</translatorcomment>
         <translation>アルケオダイノス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="199"/>
+        <location filename="Data.cpp" line="212"/>
         <source>Succube</source>
         <translatorcomment>Bomb</translatorcomment>
         <translation>ボム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="199"/>
+        <location filename="Data.cpp" line="212"/>
         <source>Tikal</source>
         <translatorcomment>Blitz</translatorcomment>
         <translation>ブリッツ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="199"/>
+        <location filename="Data.cpp" line="212"/>
         <source>Wendigo</source>
         <translatorcomment>Wendigo</translatorcomment>
         <translation>ウェンディゴ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="199"/>
+        <location filename="Data.cpp" line="212"/>
         <source>Marsupial</source>
         <translatorcomment>Torama</translatorcomment>
         <translation>クアール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="199"/>
+        <location filename="Data.cpp" line="212"/>
         <source>Draconus</source>
         <translatorcomment>Imp</translatorcomment>
         <translation>ガルキマセラ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="200"/>
+        <location filename="Data.cpp" line="213"/>
         <source>Moloch</source>
         <translatorcomment>Blue Dragon</translatorcomment>
         <translation>ドラゴンイゾルデ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="200"/>
+        <location filename="Data.cpp" line="213"/>
         <source>Ao</source>
         <translatorcomment>Adamantoise</translatorcomment>
         <translation>アダマンタイマイ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="200"/>
+        <location filename="Data.cpp" line="213"/>
         <source>Polyphage</source>
         <translatorcomment>Hexadragon</translatorcomment>
         <translation>メルトドラゴン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="200"/>
+        <location filename="Data.cpp" line="213"/>
         <source>Ekarissor</source>
         <translatorcomment>Iron Giant</translatorcomment>
         <translation>鉄巨人</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="200"/>
+        <location filename="Data.cpp" line="213"/>
         <source>Kanibal</source>
         <translatorcomment>Behemoth</translatorcomment>
         <translation>ベヒーモス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="200"/>
+        <location filename="Data.cpp" line="213"/>
         <source>Chimaira</source>
         <translatorcomment>Chimera</translatorcomment>
         <translation>キマイラブレイン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="201"/>
+        <location filename="Data.cpp" line="214"/>
         <source>Koyo K</source>
         <translatorcomment>PuPu</translatorcomment>
         <translation>コヨコヨ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="201"/>
+        <location filename="Data.cpp" line="214"/>
         <source>Protesis</source>
         <translatorcomment>Elastoid</translatorcomment>
         <translation>インビンシブル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="201"/>
+        <location filename="Data.cpp" line="214"/>
         <source>Pikasso</source>
         <translatorcomment>GIM47N</translatorcomment>
         <translation>GIM47N</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="201"/>
+        <location filename="Data.cpp" line="214"/>
         <source>Xylomid</source>
         <translatorcomment>Malboro</translatorcomment>
         <translation>モルボル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="201"/>
+        <location filename="Data.cpp" line="214"/>
         <source>Griffon</source>
         <translatorcomment>Ruby Dragon</translatorcomment>
         <translation>ルブルムドラゴン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="201"/>
+        <location filename="Data.cpp" line="214"/>
         <source>Sulfor</source>
         <translatorcomment>Elnoyle</translatorcomment>
         <translation>エルノーイル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="202"/>
+        <location filename="Data.cpp" line="215"/>
         <source>Tomberry Sr</source>
         <translatorcomment>Tonberry King</translatorcomment>
         <translation>トンベリキング</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="202"/>
+        <location filename="Data.cpp" line="215"/>
         <source>Wedge/Biggs</source>
         <translatorcomment>Wedge, Biggs</translatorcomment>
         <translation>ウェッジ・ビッグス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="202"/>
+        <location filename="Data.cpp" line="215"/>
         <source>Fujin/Raijin</source>
         <translatorcomment>Fujin, Raijin</translatorcomment>
         <translation>風神・雷神</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="202"/>
+        <location filename="Data.cpp" line="215"/>
         <source>Sulfura</source>
         <translatorcomment>Elvoret</translatorcomment>
         <translation>エルヴィオレ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="202"/>
+        <location filename="Data.cpp" line="215"/>
         <source>Goliath</source>
         <translatorcomment>X-ATM092</translatorcomment>
         <translation>X-ATM092</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="203"/>
+        <location filename="Data.cpp" line="216"/>
         <source>Lygus</source>
         <translatorcomment>Granaldo</translatorcomment>
         <translation>グラナルド</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="203"/>
+        <location filename="Data.cpp" line="216"/>
         <source>Écorché</source>
         <translatorcomment>Gerogero</translatorcomment>
         <translation>ナムタル・ウトク</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="203"/>
+        <location filename="Data.cpp" line="216"/>
         <source>Iguanor</source>
         <translatorcomment>Iguion</translatorcomment>
         <translation>シュメルケ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="203"/>
+        <location filename="Data.cpp" line="216"/>
         <source>Hornet</source>
         <translatorcomment>Abadon</translatorcomment>
         <translation>アバドン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="203"/>
+        <location filename="Data.cpp" line="216"/>
         <source>Flotix</source>
         <translatorcomment>Trauma</translatorcomment>
         <translation>ドルメン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="203"/>
+        <location filename="Data.cpp" line="216"/>
         <source>Cyanide</source>
         <translatorcomment>Oilboyle</translatorcomment>
         <translation>オイルシッパー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="204"/>
+        <location filename="Data.cpp" line="217"/>
         <source>Shumi</source>
         <translatorcomment>Shumi</translatorcomment>
         <translation>シュミ族</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="204"/>
+        <location filename="Data.cpp" line="217"/>
         <source>Krystal</source>
         <translatorcomment>Krysta</translatorcomment>
         <translation>コキュートス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="204"/>
+        <location filename="Data.cpp" line="217"/>
         <source>Alienator</source>
         <translatorcomment>Propagator</translatorcomment>
         <translation>プロパゲーター</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="204"/>
+        <location filename="Data.cpp" line="217"/>
         <source>Pampa Sr</source>
         <translatorcomment>Jumbo Cactuar</translatorcomment>
         <translation>ジャボテンダー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="204"/>
+        <location filename="Data.cpp" line="217"/>
         <source>Acron</source>
         <translatorcomment>Tri-Point</translatorcomment>
         <translation>トライエッジ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="204"/>
+        <location filename="Data.cpp" line="217"/>
         <source>Agamemnon</source>
         <translatorcomment>Gargantua</translatorcomment>
         <translation>ガルガンチュア</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="205"/>
+        <location filename="Data.cpp" line="218"/>
         <source>Anakronox</source>
         <translatorcomment>Mobile Type 8</translatorcomment>
         <translation>機動兵器8型BIS</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="205"/>
+        <location filename="Data.cpp" line="218"/>
         <source>Mithra</source>
         <translatorcomment>Sphinxara</translatorcomment>
         <translation>アンドロ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="205"/>
+        <location filename="Data.cpp" line="218"/>
         <source>Acarnan</source>
         <translatorcomment>Tiamat</translatorcomment>
         <translation>ティアマト</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="205"/>
+        <location filename="Data.cpp" line="218"/>
         <source>Omniborg</source>
         <translatorcomment>BGH251F2</translatorcomment>
         <translation>BGH251F2</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="205"/>
+        <location filename="Data.cpp" line="218"/>
         <source>Attila</source>
         <translatorcomment>Red Giant</translatorcomment>
         <translation>ウルフラマイター</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="205"/>
+        <location filename="Data.cpp" line="218"/>
         <source>Fabryce</source>
         <translatorcomment>Catoblepas</translatorcomment>
         <translation>カトブレパス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="206"/>
+        <location filename="Data.cpp" line="219"/>
         <source>Monarch</source>
         <translatorcomment>Ultima Weapon</translatorcomment>
         <translation>アルテマウェポン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="216"/>
+        <location filename="Data.cpp" line="229"/>
         <source>Dummy</source>
         <comment>Ennemy</comment>
         <translation>ダミー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="216"/>
+        <location filename="Data.cpp" line="229"/>
         <source>ExoSkelet</source>
         <comment>Ennemy</comment>
         <translation>GIM52A</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="216"/>
+        <location filename="Data.cpp" line="229"/>
         <source>Incube</source>
         <comment>Ennemy</comment>
         <translation>プリヌラ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="216"/>
+        <location filename="Data.cpp" line="229"/>
         <source>Malaku</source>
         <comment>Ennemy</comment>
         <translation>スラストエイビス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="217"/>
+        <location filename="Data.cpp" line="230"/>
         <source>Bogomile</source>
         <comment>Ennemy</comment>
         <translation>ハウリザード</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="217"/>
+        <location filename="Data.cpp" line="230"/>
         <source>Koatl</source>
         <comment>Ennemy</comment>
         <translation>ベルヘルメルヘル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="217"/>
+        <location filename="Data.cpp" line="230"/>
         <source>Xylopode</source>
         <comment>Ennemy</comment>
         <translation>グヘイスアイ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="217"/>
+        <location filename="Data.cpp" line="230"/>
         <source>Barbarian</source>
         <comment>Ennemy</comment>
         <translation>SAM08G</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="218"/>
+        <location filename="Data.cpp" line="231"/>
         <source>Pikasso</source>
         <comment>Ennemy</comment>
         <translation>GIM47N</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="218"/>
+        <location filename="Data.cpp" line="231"/>
         <source>Licorne</source>
         <comment>Ennemy</comment>
         <translation>メズマライズ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="218"/>
+        <location filename="Data.cpp" line="231"/>
         <source>Schizoïd</source>
         <comment>Ennemy</comment>
         <translation>ブエル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="218"/>
+        <location filename="Data.cpp" line="231"/>
         <source>Brahman</source>
         <comment>Ennemy</comment>
         <translatorcomment>Sphinxaur</translatorcomment>
         <translation>スフィンクス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="219"/>
+        <location filename="Data.cpp" line="232"/>
         <source>Shiva</source>
         <comment>Ennemy</comment>
         <translation>シヴァ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="219"/>
+        <location filename="Data.cpp" line="232"/>
         <source>Satyrux</source>
         <comment>Ennemy</comment>
         <translation>ゴージュシール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="219"/>
+        <location filename="Data.cpp" line="232"/>
         <source>Arconada</source>
         <comment>Ennemy</comment>
         <translation>ヘッジヴァイパー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="219"/>
+        <location filename="Data.cpp" line="232"/>
         <source>Orchida</source>
         <comment>Ennemy</comment>
         <translation>グラット</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="220"/>
+        <location filename="Data.cpp" line="233"/>
         <source>Gallus</source>
         <comment>Ennemy</comment>
         <translation>コカトリス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="220"/>
+        <location filename="Data.cpp" line="233"/>
         <source>Larva</source>
         <comment>Ennemy</comment>
         <translation>ケダチク</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="220"/>
+        <location filename="Data.cpp" line="233"/>
         <source>Nocturnus</source>
         <comment>Ennemy</comment>
         <translation>レッドマウス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="220"/>
+        <location filename="Data.cpp" line="233"/>
         <source>Tikal</source>
         <comment>Ennemy</comment>
         <translation>ブリッツ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="221"/>
+        <location filename="Data.cpp" line="234"/>
         <source>Diodon</source>
         <comment>Ennemy</comment>
         <translatorcomment>フォカロル (ライブラ), Fastitocalon●
@@ -8041,7 +8161,7 @@ Diodon = Fastitocalon-F = フォカロルフェイク</translatorcomment>
         <translation>フォカロル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="221"/>
+        <location filename="Data.cpp" line="234"/>
         <source>Phantom</source>
         <comment>Ennemy</comment>
         <translatorcomment>フォカロルフェイク (ライブラ), Fastitocalon●
@@ -8050,309 +8170,309 @@ Diodon = Fastitocalon-F = フォカロルフェイク</translatorcomment>
         <translation>フォカロル（小）</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="221"/>
+        <location filename="Data.cpp" line="234"/>
         <source>Elastos</source>
         <comment>Ennemy</comment>
         <translation>ゲスパー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="221"/>
+        <location filename="Data.cpp" line="234"/>
         <source>Formicide</source>
         <comment>Ennemy</comment>
         <translation>クリープス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="222"/>
+        <location filename="Data.cpp" line="235"/>
         <source>Polyphage</source>
         <comment>Ennemy</comment>
         <translation>メルトドラゴン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="222"/>
+        <location filename="Data.cpp" line="235"/>
         <source>Carnidea</source>
         <comment>Ennemy</comment>
         <translation>ブラットソウル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="222"/>
+        <location filename="Data.cpp" line="235"/>
         <source>Protesis</source>
         <comment>Ennemy</comment>
         <translation>インビンシブル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="222"/>
+        <location filename="Data.cpp" line="235"/>
         <source>Scavenger</source>
         <comment>Ennemy</comment>
         <translation>エサンスーシ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="223"/>
+        <location filename="Data.cpp" line="236"/>
         <source>Elmidea</source>
         <comment>Ennemy</comment>
         <translation>バイトバグ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="223"/>
+        <location filename="Data.cpp" line="236"/>
         <source>Héra</source>
         <comment>Ennemy</comment>
         <translation>ダブルハガー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="223"/>
+        <location filename="Data.cpp" line="236"/>
         <source>Acron</source>
         <comment>Ennemy</comment>
         <translation>トライエッジ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="223"/>
+        <location filename="Data.cpp" line="236"/>
         <source>Eiffel</source>
         <comment>Ennemy</comment>
         <translation>グラナトゥム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="224"/>
+        <location filename="Data.cpp" line="237"/>
         <source>Wendigo</source>
         <comment>Ennemy</comment>
         <translation>ウェンディゴ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="224"/>
+        <location filename="Data.cpp" line="237"/>
         <source>Aphide</source>
         <comment>Ennemy</comment>
         <translation>ゲイラ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="224"/>
+        <location filename="Data.cpp" line="237"/>
         <source>Ecorché</source>
         <comment>Ennemy</comment>
         <translation>ナムタル・ウトク</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="224"/>
+        <location filename="Data.cpp" line="237"/>
         <source>Berserker</source>
         <comment>Ennemy</comment>
         <translation>ワイルドフック</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="225"/>
+        <location filename="Data.cpp" line="238"/>
         <source>Adéphage</source>
         <comment>Ennemy</comment>
         <translation>トライフェイス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="225"/>
+        <location filename="Data.cpp" line="238"/>
         <source>Selek</source>
         <comment>Ennemy</comment>
         <translation>グランデアーロ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="225"/>
+        <location filename="Data.cpp" line="238"/>
         <source>Krystal</source>
         <comment>Ennemy</comment>
         <translation>コキュートス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="225"/>
+        <location filename="Data.cpp" line="238"/>
         <source>Gangrène</source>
         <comment>Ennemy</comment>
         <translation>ゴーマニ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="226"/>
+        <location filename="Data.cpp" line="239"/>
         <source>Fatima</source>
         <comment>Ennemy</comment>
         <translation>ドロマニ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="226"/>
+        <location filename="Data.cpp" line="239"/>
         <source>Moloch</source>
         <comment>Ennemy</comment>
         <translation>ドラゴンイゾルデ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="226"/>
+        <location filename="Data.cpp" line="239"/>
         <source>Weevil</source>
         <comment>Ennemy</comment>
         <translation>ライフフォビドン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="226"/>
+        <location filename="Data.cpp" line="239"/>
         <source>Succube</source>
         <comment>Ennemy</comment>
         <translation>ボム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="227"/>
+        <location filename="Data.cpp" line="240"/>
         <source>Célébis</source>
         <comment>Ennemy</comment>
         <translation>アビスウォーム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="227"/>
+        <location filename="Data.cpp" line="240"/>
         <source>Trogiidae</source>
         <comment>Ennemy</comment>
         <translation>オチュー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="227"/>
+        <location filename="Data.cpp" line="240"/>
         <source>Ao</source>
         <comment>Ennemy</comment>
         <translation>アダマンタイマイ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="227"/>
+        <location filename="Data.cpp" line="240"/>
         <source>Chimaira</source>
         <comment>Ennemy</comment>
         <translation>キマイラブレイン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="228"/>
+        <location filename="Data.cpp" line="241"/>
         <source>Xylomid</source>
         <comment>Ennemy</comment>
         <translation>モルボル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="228"/>
+        <location filename="Data.cpp" line="241"/>
         <source>Ekarissor</source>
         <comment>Ennemy</comment>
         <translation>鉄巨人</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="228"/>
+        <location filename="Data.cpp" line="241"/>
         <source>Kanibal</source>
         <comment>Ennemy</comment>
         <translation>ベヒーモス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="228"/>
+        <location filename="Data.cpp" line="241"/>
         <source>T-Rex</source>
         <comment>Ennemy</comment>
         <translation>アルケオダイノス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="229"/>
+        <location filename="Data.cpp" line="242"/>
         <source>Griffon</source>
         <comment>Ennemy</comment>
         <translation>ルブルムドラゴン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="229"/>
+        <location filename="Data.cpp" line="242"/>
         <source>Feng</source>
         <comment>Ennemy</comment>
         <translation>グレンデル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="229"/>
+        <location filename="Data.cpp" line="242"/>
         <source>Cariatide</source>
         <comment>Ennemy</comment>
         <translation>バイセージ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="229"/>
+        <location filename="Data.cpp" line="242"/>
         <source>Pampa</source>
         <comment>Ennemy</comment>
         <translation>サボテンダー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="230"/>
+        <location filename="Data.cpp" line="243"/>
         <source>Tomberry</source>
         <comment>Ennemy</comment>
         <translation>トンベリ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="230"/>
+        <location filename="Data.cpp" line="243"/>
         <source>Marsupial</source>
         <comment>Ennemy</comment>
         <translation>クアール</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="230"/>
+        <location filename="Data.cpp" line="243"/>
         <source>Fungus</source>
         <comment>Ennemy</comment>
         <translation>フンゴオンゴ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="230"/>
+        <location filename="Data.cpp" line="243"/>
         <source>Draconus</source>
         <comment>Ennemy</comment>
         <translation>ガルキマセラ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="231"/>
+        <location filename="Data.cpp" line="244"/>
         <source>Koyo K</source>
         <comment>Ennemy</comment>
         <translation>コヨコヨ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="231"/>
+        <location filename="Data.cpp" line="244"/>
         <source>Ifrit</source>
         <comment>Ennemy</comment>
         <translation>イフリート</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="231"/>
+        <location filename="Data.cpp" line="244"/>
         <source>Taurux</source>
         <comment>Ennemy</comment>
         <translation>ミノタウロス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="231"/>
+        <location filename="Data.cpp" line="244"/>
         <source>Tauros</source>
         <comment>Ennemy</comment>
         <translation>セクレト</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="232"/>
+        <location filename="Data.cpp" line="245"/>
         <source>Commandeur</source>
         <comment>Ennemy</comment>
         <translatorcomment>ミサイル基地●</translatorcomment>
         <translation>コマンドリーダー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="232"/>
+        <location filename="Data.cpp" line="245"/>
         <source>Cerbères</source>
         <comment>Ennemy</comment>
         <translation>ケルベロス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="232"/>
+        <location filename="Data.cpp" line="245"/>
         <source>Nosferatu</source>
         <comment>Ennemy</comment>
         <translation>ディアボロス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="232"/>
+        <location filename="Data.cpp" line="245"/>
         <source>Bahamut</source>
         <comment>Ennemy</comment>
         <translation>バハムート</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="233"/>
+        <location filename="Data.cpp" line="246"/>
         <source>Odyssey</source>
         <comment>Ennemy</comment>
         <translatorcomment>●「</translatorcomment>
         <translation>セルト・ヒサーリ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="233"/>
+        <location filename="Data.cpp" line="246"/>
         <source>Templier</source>
         <comment>Ennemy</comment>
         <translation>ガーデン教師</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="233"/>
+        <location filename="Data.cpp" line="246"/>
         <source>Odin</source>
         <comment>Ennemy</comment>
         <translation>オーディン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="233"/>
+        <location filename="Data.cpp" line="246"/>
         <source>Galbadien</source>
         <comment>Ennemy</comment>
         <translation>ガルバディア兵</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="234"/>
+        <location filename="Data.cpp" line="247"/>
         <source>Elite-T</source>
         <comment>Ennemy</comment>
         <translation>エリート兵</translation>
@@ -8368,591 +8488,597 @@ Diodon = Fastitocalon-F = フォカロルフェイク</translatorcomment>
         <translation type="obsolete">ビッグス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="234"/>
+        <location filename="Data.cpp" line="247"/>
         <source>Doublure</source>
         <comment>Ennemy</comment>
         <translation>デリング偽大統領</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="235"/>
+        <location filename="Data.cpp" line="248"/>
         <source>Trooper</source>
         <comment>Ennemy</comment>
         <translation>警備員</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="235"/>
+        <location filename="Data.cpp" line="248"/>
         <source>Norg</source>
         <comment>Ennemy</comment>
         <translation>ノーグ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="235"/>
+        <location filename="Data.cpp" line="248"/>
         <source>S-Borg</source>
         <comment>Ennemy</comment>
         <translatorcomment>●</translatorcomment>
         <translation>エスタ兵</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="235"/>
+        <location filename="Data.cpp" line="248"/>
         <source>T-Borg</source>
         <comment>Ennemy</comment>
         <translatorcomment>●</translatorcomment>
         <translation>エスタ兵 (ターミネーター)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="236"/>
+        <location filename="Data.cpp" line="249"/>
         <source>Tupolev</source>
         <comment>Ennemy</comment>
         <translatorcomment>●</translatorcomment>
         <translation>ソルト・ヒサーリ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="236"/>
+        <location filename="Data.cpp" line="249"/>
         <source>Spootnik</source>
         <comment>Ennemy</comment>
         <translatorcomment>●</translatorcomment>
         <translation>サグト・ヒサーリ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="237"/>
+        <location filename="Data.cpp" line="250"/>
         <source>Seifer (1)</source>
         <comment>Ennemy</comment>
         <translation>サイファー (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="237"/>
+        <location filename="Data.cpp" line="250"/>
         <source>Seifer (2)</source>
         <comment>Ennemy</comment>
         <translation>サイファー (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="237"/>
+        <location filename="Data.cpp" line="250"/>
         <source>Seifer (3)</source>
         <comment>Ennemy</comment>
         <translation>サイファー (3)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="236"/>
+        <location filename="Data.cpp" line="249"/>
         <source>Tomberry Sr</source>
         <comment>Ennemy</comment>
         <translation>トンベリキング</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="234"/>
+        <location filename="Data.cpp" line="247"/>
         <source>Wedge (1)</source>
         <comment>Ennemy</comment>
         <translation>ウェッジ (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="234"/>
+        <location filename="Data.cpp" line="247"/>
         <source>Biggs (1)</source>
         <comment>Ennemy</comment>
         <translation>ビッグス (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="236"/>
+        <location filename="Data.cpp" line="249"/>
         <source>Gunblade (1)</source>
         <comment>Ennemy</comment>
         <translation>ガンブレード (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="237"/>
+        <location filename="Data.cpp" line="250"/>
         <source>Pampa Senior</source>
         <comment>Ennemy</comment>
         <translation>ジャボテンダー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="238"/>
+        <location filename="Data.cpp" line="251"/>
         <source>Edea (1)</source>
         <oldsource>Edea</oldsource>
         <comment>Ennemy</comment>
         <translation>イデア (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="238"/>
+        <location filename="Data.cpp" line="251"/>
         <source>Monarch</source>
         <comment>Ennemy</comment>
         <translation>アルテマウェポン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="238"/>
+        <location filename="Data.cpp" line="251"/>
         <source>Sulfura</source>
         <comment>Ennemy</comment>
         <translation>エルヴィオレ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="238"/>
+        <location filename="Data.cpp" line="251"/>
         <source>Alienator (violet)</source>
         <comment>Ennemy</comment>
         <translatorcomment>Propagator (purple)</translatorcomment>
         <translation>プロパゲーター (紫)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="239"/>
+        <location filename="Data.cpp" line="252"/>
         <source>Goliath</source>
         <comment>Ennemy</comment>
         <translation>X-ATM092</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="239"/>
+        <location filename="Data.cpp" line="252"/>
         <source>Iguanor</source>
         <comment>Ennemy</comment>
         <translation>シュメルケ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="239"/>
+        <location filename="Data.cpp" line="252"/>
         <source>Agamemnon</source>
         <comment>Ennemy</comment>
         <translation>ガルガンチュア</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="239"/>
+        <location filename="Data.cpp" line="252"/>
         <source>Lygus</source>
         <comment>Ennemy</comment>
         <translation>グラナルド</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="240"/>
+        <location filename="Data.cpp" line="253"/>
         <source>Cujo</source>
         <comment>Ennemy</comment>
         <translation>ラルド</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="240"/>
+        <location filename="Data.cpp" line="253"/>
         <source>Cyanide</source>
         <comment>Ennemy</comment>
         <translation>オイルシッパー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="240"/>
+        <location filename="Data.cpp" line="253"/>
         <source>Alienator (vert)</source>
         <comment>Ennemy</comment>
         <translatorcomment>Propagator (green)</translatorcomment>
         <translation>プロパゲーター (緑)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="240"/>
+        <location filename="Data.cpp" line="253"/>
         <source>Alienator (jaune)</source>
         <comment>Ennemy</comment>
         <translatorcomment>Propagator (yellow)</translatorcomment>
         <translation>プロパゲーター (黄)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="241"/>
+        <location filename="Data.cpp" line="254"/>
         <source>Hornet</source>
         <comment>Ennemy</comment>
         <translatorcomment>バトルタブの表示に使用</translatorcomment>
         <translation>アバドン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="241"/>
+        <location filename="Data.cpp" line="254"/>
         <source>Edea (2)</source>
         <comment>Ennemy</comment>
         <translation>イデア (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="241"/>
+        <location filename="Data.cpp" line="254"/>
         <source>Omniborg (1)</source>
         <comment>Ennemy</comment>
         <translation>BGH251F2 (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="241"/>
+        <location filename="Data.cpp" line="254"/>
         <source>Omniborg (2)</source>
         <comment>Ennemy</comment>
         <translation>BGH251F2 (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="242"/>
+        <location filename="Data.cpp" line="255"/>
         <source>Anakronox</source>
         <comment>Ennemy</comment>
         <translation>機動兵器8型BIS</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="242"/>
+        <location filename="Data.cpp" line="255"/>
         <source>A-G Pod</source>
         <comment>Ennemy</comment>
         <translation>支援兵器Ｌ型</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="242"/>
+        <location filename="Data.cpp" line="255"/>
         <source>A-D Pod</source>
         <comment>Ennemy</comment>
         <translation>支援兵器Ｒ型</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="242"/>
+        <location filename="Data.cpp" line="255"/>
         <source>Hornet (zombie)</source>
         <comment>Ennemy</comment>
         <translation>アバドン (ゾンビ？)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="243"/>
+        <location filename="Data.cpp" line="256"/>
         <source>ParaBorg</source>
         <comment>Ennemy</comment>
         <translation>パラ・トルーパー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="243"/>
+        <location filename="Data.cpp" line="256"/>
         <source>Flotix</source>
         <comment>Ennemy</comment>
         <translation>ドルメン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="243"/>
+        <location filename="Data.cpp" line="256"/>
         <source>Bibendum</source>
         <comment>Ennemy</comment>
         <translation>アリニュメン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="243"/>
+        <location filename="Data.cpp" line="256"/>
         <source>Alienator (rouge)</source>
         <comment>Ennemy</comment>
         <translatorcomment>Propagator (red)</translatorcomment>
         <translation>プロパゲーター (赤)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="244"/>
+        <location filename="Data.cpp" line="257"/>
         <source>Adel</source>
         <comment>Ennemy</comment>
         <translation>アデル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="244"/>
+        <location filename="Data.cpp" line="257"/>
         <source>Nécromancienne (1)</source>
         <comment>Ennemy</comment>
         <translation>魔女 (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="245"/>
+        <location filename="Data.cpp" line="258"/>
         <source>Fujin (1)</source>
         <comment>Ennemy</comment>
         <translation>風神 (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="245"/>
+        <location filename="Data.cpp" line="258"/>
         <source>Nécromancienne (2)</source>
         <comment>Ennemy</comment>
         <translation>魔女 (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="245"/>
+        <location filename="Data.cpp" line="258"/>
         <source>Nécromancienne (3)</source>
         <comment>Ennemy</comment>
         <translation>魔女 (3)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="246"/>
+        <location filename="Data.cpp" line="259"/>
         <source>Raijin (1)</source>
         <comment>Ennemy</comment>
         <translation>雷神 (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="246"/>
+        <location filename="Data.cpp" line="259"/>
         <source>(Sans nom)</source>
         <comment>Ennemy</comment>
         <translation>(名称なし)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="246"/>
+        <location filename="Data.cpp" line="259"/>
         <source>Ultimecia (1)</source>
         <comment>Ennemy</comment>
         <translation>アルティミシア (1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="246"/>
+        <location filename="Data.cpp" line="259"/>
         <source>Ultimecia (2)</source>
         <comment>Ennemy</comment>
         <translation>アルティミシア (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="247"/>
+        <location filename="Data.cpp" line="260"/>
         <source>Seifer (4)</source>
         <comment>Ennemy</comment>
         <translation>サイファー (4)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="247"/>
+        <location filename="Data.cpp" line="260"/>
         <source>Ultimecia (3)</source>
         <comment>Ennemy</comment>
         <translation>アルティミシア (3)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="247"/>
+        <location filename="Data.cpp" line="260"/>
         <source>Ultimecia (4)</source>
         <comment>Ennemy</comment>
         <translation>アルティミシア (4)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="249"/>
+        <location filename="Data.cpp" line="262"/>
         <source>Fujin (2)</source>
         <comment>Ennemy</comment>
         <translation>風神 (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="249"/>
+        <location filename="Data.cpp" line="262"/>
         <source>Raijin (2)</source>
         <comment>Ennemy</comment>
         <translation>雷神 (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="249"/>
+        <location filename="Data.cpp" line="262"/>
         <source>Biggs (2)</source>
         <comment>Ennemy</comment>
         <translation>ビッグス (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="250"/>
+        <location filename="Data.cpp" line="262"/>
+        <source>Wedge (2)</source>
+        <comment>Ennemy</comment>
+        <translation>ウェッジ (2)</translation>
+    </message>
+    <message>
+        <location filename="Data.cpp" line="263"/>
         <source>UFO (Mandy Beach)</source>
         <comment>Ennemy</comment>
         <translation>UFO (マンデービーチ)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="250"/>
+        <location filename="Data.cpp" line="263"/>
         <source>UFO (Winhill)</source>
         <comment>Ennemy</comment>
         <translation>UFO (ウィンヒル)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="250"/>
+        <location filename="Data.cpp" line="263"/>
         <source>UFO (Trabia)</source>
         <comment>Ennemy</comment>
         <translation>UFO (トラビア)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="250"/>
+        <location filename="Data.cpp" line="263"/>
         <source>UFO (Désert Kashkabald)</source>
         <comment>Ennemy</comment>
         <translation>UFO (カシュクバール砂漠)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="251"/>
+        <location filename="Data.cpp" line="264"/>
         <source>Gunblade (2)</source>
         <oldsource>Gunblade 2</oldsource>
         <comment>Ennemy</comment>
         <translation>ガンブレード (2)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="811"/>
+        <location filename="Data.cpp" line="825"/>
         <source>Utilisée</source>
         <translatorcomment>Used Up</translatorcomment>
         <translation>消滅</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="816"/>
+        <location filename="Data.cpp" line="830"/>
         <source> (carte %1)</source>
         <translation>(カード %1)</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="244"/>
+        <location filename="Data.cpp" line="257"/>
         <source>Minotaure</source>
         <comment>Ennemy</comment>
         <translation>オメガウェポン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="245"/>
+        <location filename="Data.cpp" line="258"/>
         <source>UFO</source>
         <comment>Ennemy</comment>
         <translation>ＵＦＯ？</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="247"/>
+        <location filename="Data.cpp" line="260"/>
         <source>Hélix</source>
         <comment>Ennemy</comment>
         <translation>ヘリックス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="247"/>
+        <location filename="Data.cpp" line="260"/>
         <source>Jason</source>
         <comment>Ennemy</comment>
         <translation>スラッパー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="248"/>
+        <location filename="Data.cpp" line="261"/>
         <source>Attila</source>
         <comment>Ennemy</comment>
         <translation>ウルフラマイター</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="248"/>
+        <location filename="Data.cpp" line="261"/>
         <source>Sulfor</source>
         <comment>Ennemy</comment>
         <translation>エルノーイル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="248"/>
+        <location filename="Data.cpp" line="261"/>
         <source>Acarnan</source>
         <comment>Ennemy</comment>
         <translation>ティアマト</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="248"/>
+        <location filename="Data.cpp" line="261"/>
         <source>Fabryce</source>
         <comment>Ennemy</comment>
         <translation>カトブレパス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="251"/>
+        <location filename="Data.cpp" line="264"/>
         <source>Soldat</source>
         <comment>Ennemy</comment>
         <translation>コマンド兵</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="85"/>
+        <location filename="Data.cpp" line="86"/>
         <source>Golgotha</source>
         <comment>item</comment>
         <translatorcomment>Phoenix Pinion</translatorcomment>
         <translation>フェニックスの羽</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="159"/>
+        <location filename="Data.cpp" line="172"/>
         <source>Shiva</source>
         <comment>gf</comment>
         <translatorcomment>Shiva</translatorcomment>
         <translation>シヴァ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="159"/>
+        <location filename="Data.cpp" line="172"/>
         <source>Ifrit</source>
         <comment>gf</comment>
         <translatorcomment>Ifrit</translatorcomment>
         <translation>イフリート</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="159"/>
+        <location filename="Data.cpp" line="172"/>
         <source>Ondine</source>
         <comment>gf</comment>
         <translatorcomment>Siren</translatorcomment>
         <translation>セイレーン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="160"/>
+        <location filename="Data.cpp" line="173"/>
         <source>Taurus</source>
         <comment>gf</comment>
         <translatorcomment>Brothers</translatorcomment>
         <translation>ブラザーズ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="160"/>
+        <location filename="Data.cpp" line="173"/>
         <source>Nosferatu</source>
         <comment>gf</comment>
         <translatorcomment>Diablos</translatorcomment>
         <translation>ディアボロス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="160"/>
+        <location filename="Data.cpp" line="173"/>
         <source>Ahuri</source>
         <comment>gf</comment>
         <translatorcomment>Carbuncle</translatorcomment>
         <translation>カーバンクル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="160"/>
+        <location filename="Data.cpp" line="173"/>
         <source>Leviathan</source>
         <comment>gf</comment>
         <translatorcomment>Leviathan</translatorcomment>
         <translation>リヴァイアサン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="161"/>
+        <location filename="Data.cpp" line="174"/>
         <source>Zéphyr</source>
         <comment>gf</comment>
         <translatorcomment>Pandemona</translatorcomment>
         <translation>パンデモニウム</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="161"/>
+        <location filename="Data.cpp" line="174"/>
         <source>Cerberus</source>
         <comment>gf</comment>
         <translatorcomment>Cerberus</translatorcomment>
         <translation>ケルベロス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="161"/>
+        <location filename="Data.cpp" line="174"/>
         <source>Alexander</source>
         <comment>gf</comment>
         <translatorcomment>Alexander</translatorcomment>
         <translation>アレクサンダー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="161"/>
+        <location filename="Data.cpp" line="174"/>
         <source>Helltrain</source>
         <comment>gf</comment>
         <translatorcomment>Doomtrain</translatorcomment>
         <translation>グラシャラボラス</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="162"/>
+        <location filename="Data.cpp" line="175"/>
         <source>Bahamut</source>
         <comment>gf</comment>
         <translatorcomment>Bahamut</translatorcomment>
         <translation>バハムート</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="162"/>
+        <location filename="Data.cpp" line="175"/>
         <source>Pampa</source>
         <comment>gf</comment>
         <translatorcomment>Cactuar</translatorcomment>
         <translation>サボテンダー</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="162"/>
+        <location filename="Data.cpp" line="175"/>
         <source>Tomberry</source>
         <comment>gf</comment>
         <translatorcomment>Tonberry</translatorcomment>
         <translation>トンベリ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="162"/>
+        <location filename="Data.cpp" line="175"/>
         <source>Orbital</source>
         <comment>gf</comment>
         <translatorcomment>Eden</translatorcomment>
         <translation>エデン</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="206"/>
+        <location filename="Data.cpp" line="219"/>
         <source>Grochocobo</source>
         <comment>card</comment>
         <translatorcomment>Chubby Chocobo</translatorcomment>
         <translation>デブチョコボ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="206"/>
+        <location filename="Data.cpp" line="219"/>
         <source>Angel</source>
         <comment>card</comment>
         <translatorcomment>Angelo</translatorcomment>
         <translation>アンジェロ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="206"/>
+        <location filename="Data.cpp" line="219"/>
         <source>Gilgamesh</source>
         <comment>card</comment>
         <translatorcomment>Gilgamesh</translatorcomment>
         <translation>ギルガメッシュ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="206"/>
+        <location filename="Data.cpp" line="219"/>
         <source>Minimog</source>
         <comment>card</comment>
         <translatorcomment>MiniMog</translatorcomment>
         <translation>コモーグリ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="206"/>
+        <location filename="Data.cpp" line="219"/>
         <source>Chicobo</source>
         <comment>card</comment>
         <translatorcomment>Chicobo</translatorcomment>
         <translation>コチョコボ</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="207"/>
+        <location filename="Data.cpp" line="220"/>
         <source>Golgotha</source>
         <comment>card</comment>
         <translatorcomment>Quezacotl</translatorcomment>
         <translation>ケツァクウァトル</translation>
     </message>
     <message>
-        <location filename="Data.cpp" line="208"/>
+        <location filename="Data.cpp" line="221"/>
         <source>Cerbères</source>
         <translatorcomment>Cerberus</translatorcomment>
         <translation>ケルベロス</translation>
@@ -8964,75 +9090,81 @@ Diodon = Fastitocalon-F = フォカロルフェイク</translatorcomment>
         <translation>true</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="168"/>
+        <location filename="SavecardData.cpp" line="170"/>
         <source>Sans nom</source>
         <translation type="unfinished">名称なし</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="222"/>
-        <location filename="SavecardData.cpp" line="276"/>
-        <location filename="SavecardData.cpp" line="530"/>
+        <location filename="SavecardData.cpp" line="224"/>
+        <location filename="SavecardData.cpp" line="280"/>
+        <location filename="SavecardData.cpp" line="559"/>
         <source>Le fichier n&apos;existe plus.
 %1</source>
         <translation>ファイルが存在しません。.
 %1</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="227"/>
-        <location filename="SavecardData.cpp" line="281"/>
-        <location filename="SavecardData.cpp" line="418"/>
+        <location filename="SavecardData.cpp" line="229"/>
+        <location filename="SavecardData.cpp" line="285"/>
+        <location filename="SavecardData.cpp" line="447"/>
         <source>Le fichier est protégé en lecture.</source>
         <translation>読み取り専用ファイル。</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="232"/>
+        <location filename="SavecardData.cpp" line="234"/>
         <source>Fichier trop court</source>
         <translation>ファイルが小さすぎます</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="292"/>
+        <location filename="SavecardData.cpp" line="296"/>
         <source>Fichier invalide</source>
         <translation>無効なファイル</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="394"/>
+        <location filename="SavecardData.cpp" line="423"/>
         <source>Impossible de créer le fichier temporaire.</source>
         <translation type="unfinished">一時ファイルが作成できません。</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="398"/>
+        <location filename="SavecardData.cpp" line="427"/>
         <source>Impossible de décompresser le fichier.</source>
         <translation type="unfinished">Unable to uncompress the file.</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="452"/>
+        <location filename="SavecardData.cpp" line="481"/>
         <source>Format invalide.</source>
         <translation type="unfinished">無効なフォーマット。</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="463"/>
+        <location filename="SavecardData.cpp" line="492"/>
         <source>La sauvegarde trouvée n&apos;est pas de Final Fantasy VIII.</source>
         <translation type="unfinished">見つかったセーブはファイナルファンタジーVIIIからきません。</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="535"/>
+        <location filename="SavecardData.cpp" line="564"/>
         <source>Le fichier est protégé en lecture.
 %1</source>
         <translation>ファイルは読み取り専用属性です.
 %1</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="541"/>
-        <location filename="SavecardData.cpp" line="633"/>
-        <location filename="SavecardData.cpp" line="726"/>
-        <location filename="SavecardData.cpp" line="781"/>
+        <location filename="SavecardData.cpp" line="570"/>
+        <location filename="SavecardData.cpp" line="673"/>
+        <location filename="SavecardData.cpp" line="778"/>
+        <location filename="SavecardData.cpp" line="839"/>
         <source>Impossible de créer un fichier temporaire</source>
         <translation>一時ファイルが作成できません</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="606"/>
-        <location filename="SavecardData.cpp" line="755"/>
-        <location filename="SavecardData.cpp" line="835"/>
+        <location filename="SavecardData.cpp" line="624"/>
+        <source>Type non supporté pour la sauvegarde.
+%1</source>
+        <translation type="unfinished">Unsupported type %1</translation>
+    </message>
+    <message>
+        <location filename="SavecardData.cpp" line="642"/>
+        <location filename="SavecardData.cpp" line="809"/>
+        <location filename="SavecardData.cpp" line="895"/>
         <source>Impossible de supprimer le fichier !
 %1
 Échec de la sauvegarde.
@@ -9043,42 +9175,42 @@ Vérifiez que le fichier n&apos;est pas utilisé par un autre programme.</source
 他のプログラムがファイルを使用していないか確認してください。</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="612"/>
-        <location filename="SavecardData.cpp" line="703"/>
-        <location filename="SavecardData.cpp" line="761"/>
-        <location filename="SavecardData.cpp" line="844"/>
+        <location filename="SavecardData.cpp" line="650"/>
+        <location filename="SavecardData.cpp" line="753"/>
+        <location filename="SavecardData.cpp" line="817"/>
+        <location filename="SavecardData.cpp" line="906"/>
         <source>Échec de la sauvegarde.</source>
         <translation>保存に失敗しました。</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="625"/>
+        <location filename="SavecardData.cpp" line="665"/>
         <source>Cette sauvegarde ne provient pas de Final Fantasy VIII.</source>
         <translation type="unfinished">そのセーブはファイナルファンタジーVIIIからきません。</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="659"/>
+        <location filename="SavecardData.cpp" line="701"/>
         <source>Le fichier &apos;metadata.xml&apos; n&apos;a pas été trouvé dans le dossier &apos;%1&apos;.
 Essayez de signer vos sauvegardes manuellement (Fichier &gt; Signer les sauv. pour le Cloud).</source>
         <translation type="unfinished">The &apos;metadata.xml&apos; file was not found in the directory &apos;%1&apos;.
 Try to sign your saves manually (File &gt; Sign saves for the Cloud).</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="662"/>
+        <location filename="SavecardData.cpp" line="704"/>
         <source>Le fichier &apos;metadata.xml&apos; n&apos;a pas pu être ouvert.
 %1</source>
         <translation type="unfinished">The &apos;metadata.xml&apos; file cannot be opened.
 %1</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="673"/>
-        <location filename="SavecardData.cpp" line="688"/>
+        <location filename="SavecardData.cpp" line="715"/>
+        <location filename="SavecardData.cpp" line="736"/>
         <source>Le fichier &apos;metadata.xml&apos; n&apos;a pas pu être mis à jour.
 %1</source>
         <translation type="unfinished">The &apos;metadata.xml&apos; file cannot be updated.
 %1</translation>
     </message>
     <message>
-        <location filename="SavecardData.cpp" line="696"/>
+        <location filename="SavecardData.cpp" line="744"/>
         <source>Impossible de supprimer le fichier !
 %1
 Échec de la sauvegarde.
@@ -9101,17 +9233,17 @@ Try to launch %2 as admin.</translation>
         <translation type="obsolete">Cannot load file contents &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="FF8Installation.cpp" line="97"/>
+        <location filename="FF8Installation.cpp" line="110"/>
         <source>FF8 Standard</source>
         <translation type="unfinished">FF8 Standard</translation>
     </message>
     <message>
-        <location filename="FF8Installation.cpp" line="99"/>
+        <location filename="FF8Installation.cpp" line="112"/>
         <source>FF8 Steam</source>
         <translation type="unfinished">FF8 Steam</translation>
     </message>
     <message>
-        <location filename="FF8Installation.cpp" line="101"/>
+        <location filename="FF8Installation.cpp" line="114"/>
         <source>FF8 personnalisé</source>
         <oldsource>FF8 personnalisÃ©</oldsource>
         <translation type="unfinished">FF8 custom</translation>
@@ -9316,39 +9448,39 @@ Verify that the file is not used by another program.</translatorcomment>
 <context>
     <name>SavecardView</name>
     <message>
-        <location filename="SavecardView.cpp" line="74"/>
+        <location filename="SavecardView.cpp" line="76"/>
         <source>Fichier supprimé</source>
         <translation>ファイルの削除</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="75"/>
+        <location filename="SavecardView.cpp" line="77"/>
         <source>Le fichier &apos;%1&apos; a été supprimé par un programme externe !</source>
         <translation>ファイルe &apos;%1&apos; は他のプログラムによって削除されました !</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="79"/>
+        <location filename="SavecardView.cpp" line="81"/>
         <source>Fichier modifié</source>
         <translation>ファイルの変更</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="80"/>
+        <location filename="SavecardView.cpp" line="82"/>
         <source>Le fichier &apos;%1&apos; a été modifié par un programme externe.</source>
         <translation>ファイル &apos;%1&apos; は他のプログラムによって変更されました。</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="203"/>
+        <location filename="SavecardView.cpp" line="205"/>
         <source>Écraser</source>
         <translation type="unfinished">Overwrite</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="203"/>
+        <location filename="SavecardView.cpp" line="205"/>
         <source>Tout le contenu de la sauvegarde sera écrasé.
 Continuer ?</source>
         <translation type="unfinished">All content of the save will be overwritten.
 Continue?</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="268"/>
+        <location filename="SavecardView.cpp" line="270"/>
         <source>Exporter</source>
         <translation>エクスポート</translation>
     </message>
@@ -9357,51 +9489,51 @@ Continue?</translation>
         <translation type="obsolete">FF8 PC セーブ (*)</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="268"/>
+        <location filename="SavecardView.cpp" line="270"/>
         <source>FF8 PC save (* *.ff8)</source>
         <translation>FF8 PC セーブ (* *.ff8)</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="275"/>
+        <location filename="SavecardView.cpp" line="277"/>
         <source>Échec</source>
         <translation>失敗</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="275"/>
+        <location filename="SavecardView.cpp" line="277"/>
         <source>Enregistrement échoué, vérifiez que le fichier cible n&apos;est pas utilisé.</source>
         <translation>保存に失敗しました。ファイルが使用中でないか確認してください。</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="291"/>
+        <location filename="SavecardView.cpp" line="293"/>
         <source>Nouvelle partie</source>
         <translation type="unfinished">ニューゲーム</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="291"/>
+        <location filename="SavecardView.cpp" line="293"/>
         <source>Tout le contenu de la sauvegarde sera remplacé par une nouvelle partie.
 Continuer ?</source>
         <translation type="unfinished">All content of the save will be replaced with a new game.
 Continue?</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="345"/>
+        <location filename="SavecardView.cpp" line="347"/>
         <source>Vider</source>
         <translation type="unfinished">空ける</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="345"/>
+        <location filename="SavecardView.cpp" line="347"/>
         <source>Tout le contenu de la sauvegarde sera vidé.
 Continuer ?</source>
         <translation type="unfinished">All content of the save will be emptied.
 Continue?</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="385"/>
+        <location filename="SavecardView.cpp" line="387"/>
         <source>Sauvegarde supprimée</source>
         <translation>削除済みのセーブ</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="385"/>
+        <location filename="SavecardView.cpp" line="387"/>
         <source>Cette sauvegarde a été supprimée, voulez-vous tenter de la réparer ? (succès non garanti)</source>
         <translation>このセーブは削除されています。修復しますか？ (成功するとは限りません)</translation>
     </message>
@@ -9414,42 +9546,42 @@ Continue?</translation>
         <translation type="obsolete">いいえ</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="496"/>
+        <location filename="SavecardView.cpp" line="498"/>
         <source>NV%1</source>
         <translation>Lv.%1</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="544"/>
+        <location filename="SavecardView.cpp" line="546"/>
         <source>Bloc occupé</source>
         <translation type="unfinished">Used block</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="549"/>
+        <location filename="SavecardView.cpp" line="551"/>
         <source>Bloc Disponible</source>
         <translation>未使用ファイルです</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="831"/>
+        <location filename="SavecardView.cpp" line="833"/>
         <source>&amp;Modifier...</source>
         <translation type="unfinished">変化する(&amp;E)...</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="832"/>
+        <location filename="SavecardView.cpp" line="834"/>
         <source>&amp;Exporter en sauv. PC...</source>
         <translation type="unfinished">PC セーブに変換(&amp;C)...</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="834"/>
+        <location filename="SavecardView.cpp" line="836"/>
         <source>&amp;Nouvelle partie</source>
         <translation type="unfinished">ニューゲーム(&amp;N)</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="836"/>
+        <location filename="SavecardView.cpp" line="838"/>
         <source>&amp;Vider</source>
         <translation type="unfinished">エンプティー(&amp;M)</translation>
     </message>
     <message>
-        <location filename="SavecardView.cpp" line="838"/>
+        <location filename="SavecardView.cpp" line="840"/>
         <source>&amp;Propriétés...</source>
         <translation type="unfinished">プロパティ(&amp;P)...</translation>
     </message>
@@ -9644,7 +9776,6 @@ Continue?</translation>
         <translation>カード</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="40"/>
         <location filename="PageWidgets/TTriadEditor.cpp" line="253"/>
         <source>Règles</source>
         <translatorcomment>Rules</translatorcomment>
@@ -9700,21 +9831,18 @@ Continue?</translation>
     </message>
     <message>
         <location filename="PageWidgets/TTriadEditor.cpp" line="239"/>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
         <source>Dollet</source>
         <translatorcomment>Dollet</translatorcomment>
         <translation>ドール</translation>
     </message>
     <message>
         <location filename="PageWidgets/TTriadEditor.cpp" line="240"/>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
         <source>Horizon</source>
         <translatorcomment>F. Horizon</translatorcomment>
         <translation>Ｆ．Ｈ．</translation>
     </message>
     <message>
         <location filename="PageWidgets/TTriadEditor.cpp" line="240"/>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
         <source>Lunar Gate</source>
         <translatorcomment>Lunar Gate</translatorcomment>
         <translation>宇宙/ルナゲート</translation>
@@ -9817,126 +9945,201 @@ Continue?</translation>
     </message>
     <message>
         <location filename="PageWidgets/TTriadEditor.cpp" line="269"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="281"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="325"/>
         <source>Aucune</source>
         <translatorcomment>None</translatorcomment>
         <translation>なし</translation>
     </message>
     <message>
         <location filename="PageWidgets/TTriadEditor.cpp" line="278"/>
+        <source>Quêtes</source>
+        <translation type="unfinished">Quests</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="294"/>
+        <source>-</source>
+        <translation>-</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="294"/>
+        <source>Valet</source>
+        <translation type="unfinished">Jack</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="294"/>
+        <source>Trèfle</source>
+        <translation type="unfinished">Clover</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="294"/>
+        <source>Carreaux</source>
+        <translation type="unfinished">Diamonds</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="294"/>
+        <source>Pique</source>
+        <translation type="unfinished">Spade</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="294"/>
+        <source>Reine de coeur</source>
+        <translation type="unfinished">Queen of heart</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="304"/>
+        <source>Nulle part</source>
+        <translation type="unfinished">該当なし</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="326"/>
+        <source>Kiros</source>
+        <translation>キロス</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="327"/>
+        <source>Irvine</source>
+        <translation>アーヴァイン</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="328"/>
+        <source>GroChocobo</source>
+        <translation type="unfinished">Chubby Chocobo</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="330"/>
+        <source>Phénix</source>
+        <translation type="unfinished">フェニックス</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="335"/>
+        <source>Quête du Groupe CC :</source>
+        <translation type="unfinished">CC Group quest:</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="339"/>
+        <source>Règle du vainqueur de la reine :</source>
+        <translation type="unfinished">Trade rule of the queen:</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="343"/>
+        <source>Région règle du vainqueur :</source>
+        <translation type="unfinished">Trade rule location:</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="347"/>
+        <source>Dernière carte créée :</source>
+        <translation type="unfinished">Last created card:</translation>
+    </message>
+    <message>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="350"/>
         <source>Divers</source>
         <translatorcomment>Miscellaneous</translatorcomment>
         <translation>その他</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="369"/>
+        <source>Nombre de victoires à la BGU :</source>
+        <translation type="unfinished">BGU Victory Count:</translation>
+    </message>
+    <message>
         <source>Balamb City</source>
         <translatorcomment>Balamb City</translatorcomment>
-        <translation>バラム</translation>
+        <translation type="vanished">バラム</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
         <source>Deling City</source>
         <translatorcomment>Deling City</translatorcomment>
-        <translation>デリングシティ</translation>
+        <translation type="vanished">デリングシティ</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
         <source>Shumi village</source>
         <translatorcomment>Shumi village</translatorcomment>
-        <translation>シュミ族の村</translation>
+        <translation type="vanished">シュミ族の村</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
         <source>Winhill</source>
         <translatorcomment>Winhill</translatorcomment>
-        <translation>ウィンヒル</translation>
+        <translation type="vanished">ウィンヒル</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="296"/>
         <source>Esthar City</source>
         <translatorcomment>Esthar City</translatorcomment>
-        <translation>エスタ</translation>
+        <translation type="vanished">エスタ</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="315"/>
         <source>MiniMog</source>
         <translatorcomment>MiniMog</translatorcomment>
-        <translation>コモーグリ</translation>
+        <translation type="vanished">コモーグリ</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="316"/>
         <source>Tauros</source>
         <translatorcomment>Sacred</translatorcomment>
-        <translation>セクレト</translation>
+        <translation type="vanished">セクレト</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="317"/>
         <source>Chicobo</source>
         <translatorcomment>Chicobo</translatorcomment>
-        <translation>チョコボ</translation>
+        <translation type="vanished">チョコボ</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="318"/>
         <source>Alexander</source>
         <translatorcomment>Alexander</translatorcomment>
-        <translation>アレクサンダー</translation>
+        <translation type="vanished">アレクサンダー</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="319"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="329"/>
         <source>Helltrain</source>
         <translatorcomment>Doomtrain</translatorcomment>
         <translation>グラシャラボラス</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="320"/>
         <source>Toutes</source>
         <translatorcomment>All</translatorcomment>
-        <translation>すべて</translation>
+        <translation type="vanished">すべて</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="322"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="358"/>
         <source>Inconnu 1 :</source>
         <translation>詳細不明 1 :</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="324"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="360"/>
         <source>Inconnu 2 :</source>
         <translation>詳細不明 2 :</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="327"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="332"/>
         <source>Dernières régions visitées :</source>
         <translatorcomment>Last region visited:</translatorcomment>
         <translation>最後にプレイしたエリア :</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="332"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="341"/>
         <source>Nombre de joueurs règle du vainqueur :</source>
         <translatorcomment>Trade rating:</translatorcomment>
         <translation>トレードのトレンド レート :</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="336"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="345"/>
         <source>Dégénération :</source>
         <translation>トレード ルールの伝播/収束 :</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="338"/>
         <source>Cartes créées :</source>
         <translatorcomment>Cards created:</translatorcomment>
-        <translation>カードの作成 :</translation>
+        <translation type="vanished">カードの作成 :</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="330"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="337"/>
         <source>Emplacement reine des cartes :</source>
         <translatorcomment>Card Queen location:</translatorcomment>
         <translation>カードクィーンの居場所 :</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="334"/>
         <source>Région :</source>
         <translatorcomment>Region:</translatorcomment>
-        <translation>トレンド エリア :</translation>
+        <translation type="vanished">トレンド エリア :</translation>
     </message>
     <message>
         <location filename="PageWidgets/TTriadEditor.cpp" line="81"/>
@@ -9957,23 +10160,23 @@ Continue?</translation>
         <translation>場所</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="340"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="363"/>
         <source>Nombre de victoires :</source>
         <translation>勝った回数 :</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="342"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="365"/>
         <source>Nombre de défaites :</source>
         <translation>負けた回数 :</translation>
     </message>
     <message>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="344"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="367"/>
         <source>Nombre d&apos;égalités :</source>
         <translation>引き分け回数 :</translation>
     </message>
     <message>
         <location filename="PageWidgets/TTriadEditor.cpp" line="179"/>
-        <location filename="PageWidgets/TTriadEditor.cpp" line="544"/>
+        <location filename="PageWidgets/TTriadEditor.cpp" line="576"/>
         <source>Squall</source>
         <translatorcomment>Squall</translatorcomment>
         <translation>スコール</translation>
@@ -10021,32 +10224,32 @@ Continue?</translation>
         <translation type="obsolete">最近使用したファイル(&amp;R)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="78"/>
-        <location filename="Window.cpp" line="918"/>
+        <location filename="Window.cpp" line="82"/>
+        <location filename="Window.cpp" line="934"/>
         <source>&amp;Fermer</source>
         <translatorcomment>&amp;Close</translatorcomment>
         <translation>閉じる(&amp;C)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="80"/>
+        <location filename="Window.cpp" line="84"/>
         <source>&amp;Quitter</source>
         <translatorcomment>&amp;Exit</translatorcomment>
         <translation>終了(&amp;Q)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="85"/>
+        <location filename="Window.cpp" line="89"/>
         <source>Fente &amp;1</source>
         <translatorcomment>Slot &amp;1</translatorcomment>
         <translation>スロット &amp;1</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="86"/>
+        <location filename="Window.cpp" line="90"/>
         <source>Fente &amp;2</source>
         <translatorcomment>Slot &amp;2</translatorcomment>
         <translation>スロット &amp;2</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="91"/>
+        <location filename="Window.cpp" line="95"/>
         <source>&amp;Paramètres</source>
         <translatorcomment>&amp;Settings</translatorcomment>
         <translation>設定(&amp;S)</translation>
@@ -10062,15 +10265,15 @@ Continue?</translation>
         <translation type="obsolete">高解像度フォント</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="116"/>
+        <location filename="Window.cpp" line="120"/>
         <source>&amp;Langue</source>
         <oldsource>&amp;Langues</oldsource>
         <translatorcomment>&amp;Language</translatorcomment>
         <translation>表示言語(&amp;L)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="138"/>
-        <location filename="Window.cpp" line="140"/>
+        <location filename="Window.cpp" line="142"/>
+        <location filename="Window.cpp" line="144"/>
         <source>&amp;?</source>
         <oldsource>?</oldsource>
         <translation>&amp;?</translation>
@@ -10120,7 +10323,7 @@ myst6re@gmail.com
  - 日本語 : Asa (麻袋)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="294"/>
+        <location filename="Window.cpp" line="298"/>
         <source>Ouvrir</source>
         <translatorcomment>Open</translatorcomment>
         <translation>開く</translation>
@@ -10136,7 +10339,7 @@ myst6re@gmail.com
         <translation type="obsolete">PS MC ファイル (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="435"/>
+        <location filename="Window.cpp" line="439"/>
         <source>VGS memorycard (*.vgs *.mem)</source>
         <oldsource>PS memorycard (*.mcr;*.ddf;*.mc;*.mcd;*.mci;*.ps;*.psm)</oldsource>
         <translatorcomment>VGS memorycard (*.vgs *.mem)</translatorcomment>
@@ -10149,28 +10352,28 @@ myst6re@gmail.com
         <translation type="obsolete">FF8 PC セーブ (*)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="474"/>
+        <location filename="Window.cpp" line="481"/>
         <source>Les formats VMP et PSV sont protégés, l&apos;enregistrement sera partiel et risque de ne pas fonctionner.
 Continuer quand même ?</source>
         <translation>VMP 形式, PSV 形式にはプロテクトがかけられています。不完全なセーブとなり、使用できなくなるかも知れません。
 それでもかまいませんか？</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="262"/>
-        <location filename="Window.cpp" line="346"/>
-        <location filename="Window.cpp" line="356"/>
-        <location filename="Window.cpp" line="580"/>
-        <location filename="Window.cpp" line="868"/>
+        <location filename="Window.cpp" line="266"/>
+        <location filename="Window.cpp" line="350"/>
+        <location filename="Window.cpp" line="360"/>
+        <location filename="Window.cpp" line="594"/>
+        <location filename="Window.cpp" line="883"/>
         <source>Erreur</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="582"/>
+        <location filename="Window.cpp" line="596"/>
         <source>Attention</source>
         <translation type="unfinished">Warning</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="868"/>
+        <location filename="Window.cpp" line="883"/>
         <source>Final Fantasy VIII n&apos;a pas pu être lancé.
 %1</source>
         <translation>Final Fantasy VIII の起動に失敗しました。.
@@ -10214,7 +10417,7 @@ Continuer quand même ?</source>
         <translation type="vanished">Japanese (日本語)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="221"/>
+        <location filename="Window.cpp" line="225"/>
         <source> - save %1</source>
         <translatorcomment> - save %1</translatorcomment>
         <translation>- セーブ %1</translation>
@@ -10241,17 +10444,17 @@ Continuer quand même ?</source>
         <translation type="unfinished">S&amp;ign saves for the Cloud...</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="63"/>
+        <location filename="Window.cpp" line="64"/>
         <source>&amp;Lancer Final Fantasy VIII</source>
         <translation type="unfinished">Final Fantasy VIII を起動(&amp;L)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="70"/>
+        <location filename="Window.cpp" line="74"/>
         <source>Nou&amp;velle fenêtre</source>
         <translation type="unfinished">新しいウインドー(&amp;W)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="71"/>
+        <location filename="Window.cpp" line="75"/>
         <source>Ple&amp;in écran</source>
         <translation type="unfinished">フルスクリーン(&amp;F)</translation>
     </message>
@@ -10265,135 +10468,140 @@ Continuer quand même ?</source>
         <translation type="obsolete">新しいウインドー</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="93"/>
+        <location filename="Window.cpp" line="97"/>
         <source>&amp;Mode Avancé</source>
         <translation type="unfinished">拡張モード(&amp;M)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="97"/>
+        <location filename="Window.cpp" line="101"/>
         <source>&amp;Images par seconde</source>
         <translation>&amp;FPS</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="98"/>
+        <location filename="Window.cpp" line="102"/>
         <source>&amp;Auto</source>
         <translation type="unfinished">オート(&amp;A)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="102"/>
+        <location filename="Window.cpp" line="106"/>
         <source>&amp;NTSC/PC (60 images/s)</source>
         <translation>&amp;NTSC/PC (60 fps)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="106"/>
+        <location filename="Window.cpp" line="110"/>
         <source>&amp;PAL (50 images/s)</source>
         <translation>&amp;PAL (50 fps)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="112"/>
+        <location filename="Window.cpp" line="116"/>
         <source>&amp;Police haute résolution</source>
         <translation type="unfinished">高解像度フォント(&amp;H)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="126"/>
+        <location filename="Window.cpp" line="130"/>
         <source>Version PC</source>
         <translation type="unfinished">PC Version</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="234"/>
+        <location filename="Window.cpp" line="238"/>
         <source>Nouveau</source>
         <translation type="unfinished">新しい</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="236"/>
+        <location filename="Window.cpp" line="240"/>
         <source>Sans nom</source>
         <translation type="unfinished">名称なし</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="238"/>
+        <location filename="Window.cpp" line="242"/>
         <source>1 sauvegarde</source>
         <translation type="unfinished">1 セーブ</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="239"/>
+        <location filename="Window.cpp" line="243"/>
         <source>15 sauvegardes</source>
         <translation type="unfinished">15 セーブ</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="316"/>
+        <location filename="Window.cpp" line="320"/>
         <source>Enregistrer ?</source>
         <translation type="unfinished">セーブしますか</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="317"/>
+        <location filename="Window.cpp" line="321"/>
         <source>Voulez-vous enregistrer &apos;%1&apos; avant de fermer ?</source>
         <translation type="unfinished">閉めるの前に&apos;%1&apos;セーブ(を)しますか</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="319"/>
+        <location filename="Window.cpp" line="323"/>
         <source>fente</source>
         <translation type="unfinished">スロット</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="346"/>
+        <location filename="Window.cpp" line="350"/>
         <source>Fichier de type inconnu.
 Voulez-vous l&apos;analyser pour obtenir le bon format ?</source>
         <translation type="unfinished">Unknown file type.
 Would you analyze it to get the right format?</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="366"/>
+        <location filename="Window.cpp" line="370"/>
         <source>Le format %1 est protégé, l&apos;enregistrement sera partiel et risque de ne pas fonctionner.</source>
         <translation>%1 形式にはプロテクトがかけられています。不完全なセーブとなり、使用できなくなるかも知れません。</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="434"/>
+        <location filename="Window.cpp" line="438"/>
         <source>PS memorycard (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm *.vm1 *.srm)</source>
         <oldsource>PS memorycard (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm *.vm1)</oldsource>
         <translation>PS MC ファイル (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm *.vm1 *.srm)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="436"/>
+        <location filename="Window.cpp" line="440"/>
         <source>GME memorycard (*.gme)</source>
         <oldsource>VGS memorycard (*.vgs;*.mem)</oldsource>
         <translatorcomment>GME memorycard (*.gme)</translatorcomment>
         <translation>GME MC ファイル (*.gme)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="437"/>
+        <location filename="Window.cpp" line="441"/>
         <source>PSN memorycard (*.vmp)</source>
         <translation>PSN MC ファイル (*.vmp)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="438"/>
+        <location filename="Window.cpp" line="442"/>
         <source>FF8 PC save (*.ff8 *)</source>
         <translation>FF8 PC セーブ (*.ff8 *)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="439"/>
+        <location filename="Window.cpp" line="443"/>
+        <source>PS4 Remaster save (*.ff8 *)</source>
+        <translation type="unfinished">PS4 Remaster save (*.ff8 *)</translation>
+    </message>
+    <message>
+        <location filename="Window.cpp" line="444"/>
         <source>PSN save (*.psv)</source>
         <translation>PSN セーブ (*.psv)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="458"/>
+        <location filename="Window.cpp" line="464"/>
         <source>Exporter</source>
         <translatorcomment>Export</translatorcomment>
         <translation>エクスポート</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="904"/>
+        <location filename="Window.cpp" line="920"/>
         <source>Par myst6re&lt;br/&gt;&lt;a href=&quot;https://sourceforge.net/projects/hyne/&quot;&gt;https://sourceforge.net/projects/hyne/&lt;/a&gt;&lt;br/&gt;&lt;br/&gt;75% modifiable&lt;br/&gt;&lt;br/&gt;Merci à :&lt;br/&gt; - Qhimm&lt;br/&gt; - Cyberman&lt;br/&gt; - sithlord48&lt;br/&gt; - Aladore384&lt;br/&gt; - suloku&lt;br/&gt;&lt;br/&gt;Traducteurs :&lt;br/&gt; - Anglais : myst6re, Vgr&lt;br/&gt; - Japonais : Asa, Sharleen</source>
         <translation>作者 : myst6re&lt;br/&gt;&lt;a href=&quot;https://sourceforge.net/projects/hyne/&quot;&gt;https://sourceforge.net/projects/hyne/&lt;/a&gt;&lt;br/&gt;&lt;br/&gt;編集可能 : 75%&lt;br/&gt;&lt;br/&gt;多謝 :&lt;br/&gt; - Qhimm&lt;br/&gt; - Cyberman&lt;br/&gt; - sithlord48&lt;br/&gt; - Aladore384&lt;br/&gt; - suloku&lt;br/&gt;&lt;br/&gt;翻訳者 :&lt;br/&gt; - 英語 : myst6re, Vgr&lt;br/&gt; - 日本語 : Asa (麻袋)</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="365"/>
-        <location filename="Window.cpp" line="473"/>
+        <location filename="Window.cpp" line="369"/>
+        <location filename="Window.cpp" line="480"/>
         <source>Sauvegarde hasardeuse</source>
         <translatorcomment>Save hazardous</translatorcomment>
         <translation>運まかせで保存</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="295"/>
+        <location filename="Window.cpp" line="299"/>
         <source>Fichiers compatibles (*.mcr *.ddf *.gme *.mc *.mcd *.mci *.ps *.psm *.vm1 *.srm *.psv save?? *.ff8 *.mem *.vgs *.vmp *.000 *.001 *.002 *.003 *.004);;FF8 PS memorycard (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm *.vm1 *.srm);;FF8 PC save (save?? *.ff8);;FF8 vgs memorycard (*.mem *.vgs);;FF8 gme memorycard (*.gme);;FF8 PSN memorycard (*.vmp);;FF8 PS3 memorycard/pSX save state (*.psv);;ePSXe save state (*.000 *.001 *.002 *.003 *.004);;Tous les fichiers (*)</source>
         <oldsource>Fichiers compatibles (*.mcr *.ddf *.gme *.mc *.mcd *.mci *.ps *.psm *.vm1 *.psv save?? *.ff8 *.mem *.vgs *.vmp *.000 *.001 *.002 *.003 *.004);;FF8 PS memorycard (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm *.vm1);;FF8 PC save (save?? *.ff8);;FF8 vgs memorycard (*.mem *.vgs);;FF8 gme memorycard (*.gme);;FF8 PSN memorycard (*.vmp);;FF8 PS3 memorycard/pSX save state (*.psv);;ePSXe save state (*.000 *.001 *.002 *.003 *.004);;Tous les fichiers (*)</oldsource>
         <translation>対応可能なファイル (*.mcr *.ddf *.gme *.mc *.mcd *.mci *.ps *.psm *.vm1 *.srm *.psv save?? *.ff8 *.mem *.vgs *.vmp *.000 *.001 *.002 *.003 *.004);;FF8 PS MC ファイル (*.mcr *.ddf *.mc *.mcd *.mci *.ps *.psm *.vm1 *.srm);;FF8 PC セーブ (save?? *.ff8);;FF8 vgs MC ファイル (*.mem *.vgs);;FF8 gme MC ファイル (*.gme);;FF8 PSN MC ファイル (*.vmp);;FF8 PS3 MC ファイル/pSX セーブステート (*.psv);;ePSXe セーブステート (*.000 *.001 *.002 *.003 *.004);;すべてのファイル (*)</translation>
@@ -10409,30 +10617,30 @@ Would you analyze it to get the right format?</translation>
         <translation type="obsolete">いいえ</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="593"/>
+        <location filename="Window.cpp" line="607"/>
         <source>Commentaire</source>
         <translation>コメント</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="662"/>
+        <location filename="Window.cpp" line="676"/>
         <source>%1 : %2</source>
         <translatorcomment>%1: %2</translatorcomment>
         <translation>%1 : %2</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="845"/>
+        <location filename="Window.cpp" line="859"/>
         <source>Paramètres modifiés</source>
         <translatorcomment>Settings changed</translatorcomment>
         <translation>設定の変更</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="846"/>
+        <location filename="Window.cpp" line="860"/>
         <source>Relancez le programme pour que les paramètres prennent effet.</source>
         <translatorcomment>Restart the program for the settings to take effect.</translatorcomment>
         <translation>設定の変更を有効化するためにプログラムを再起動してください。</translation>
     </message>
     <message>
-        <location filename="Window.cpp" line="888"/>
+        <location filename="Window.cpp" line="904"/>
         <source>À propos</source>
         <translation type="unfinished">About</translation>
     </message>


### PR DESCRIPTION
Some changes in generated Info.plist file (Mac OSX). #12 

Remove CFBundleGetInfoString, CFBundleSignature and the note about Qt.
Adding CFBundleDevelopmentRegion, CFBundleInfoDictionaryVersion, CFBundleName, CFBundleShortVersionString and CFBundleVersion. Set my company in CFBundleIdentifier.