### PR TITLE
Remove dependency on qt6core5compat

### DIFF
--- a/Hyne.pro
+++ b/Hyne.pro
@@ -9,7 +9,7 @@ VERSION = 1.11.4
 DEFINES += PROGVERSION=$$VERSION PROGNAME=Hyne
 DEFINES += QT_DISABLE_DEPRECATED_UP_TO=0x050F00
 
-QT += core core5compat gui widgets
+QT += core gui widgets
 
 # include zlib
 !win32 {

--- a/SaveData.cpp
+++ b/SaveData.cpp
@@ -20,7 +20,9 @@
 #include "FF8Text.h"
 #include "Data.h"
 #include "LZS.h"
-#include <QTextCodec>
+#include <QStringEncoder>
+#include <QStringDecoder>
+
 
 SaveData::SaveData() :
 	_freqValue(60), _id(0), _isFF8(false), _isDelete(false),
@@ -386,15 +388,13 @@ QString SaveData::shortDescription() const
 {
 	if (hasSCHeader()) {
 		try {
-			QTextCodec *codec = QTextCodec::codecForName("Shift-JIS");
-			if (codec) {
-				QByteArray desc_array = _header.mid(4, 64);
-				int index;
-				if ((index = desc_array.indexOf('\x00')) != -1) {
-					desc_array.truncate(index);
-				}
-				return codec->toUnicode(desc_array);
+			QStringDecoder decoder("Shift-JIS");
+			QByteArray desc_array = _header.mid(4, 64);
+			int index;
+			if ((index = desc_array.indexOf('\x00')) != -1) {
+				desc_array.truncate(index);
 			}
+			return decoder(desc_array);
 		} catch(...) {
 		}
 	}
@@ -408,12 +408,11 @@ void SaveData::setShortDescription(const QString &desc)
 
 		if (!desc.isEmpty()) {
 			try {
-				QTextCodec *codec = QTextCodec::codecForName("Shift-JIS");
-				if (codec) {
-					desc_data = codec->fromUnicode(desc);
-				} else {
+				QStringEncoder encoder("Shift-JIS");
+				if (!encoder.isValid()) {
 					return;
 				}
+				desc_data = encoder(desc);
 			} catch(...) {
 				return;
 			}

--- a/SavecardData.cpp
+++ b/SavecardData.cpp
@@ -21,7 +21,7 @@
 #include "Parameters.h"
 #include "LZS.h"
 #include "CryptographicHash.h"
-#include <QRegExp>
+#include <QRegularExpression>
 
 SavecardData::SavecardData(const QString &path, quint8 slot, const FF8Installation &ff8Installation) :
 	_ok(true), start(0), _isModified(false), _slot(slot), _ff8Installation(ff8Installation)
@@ -802,18 +802,15 @@ bool SavecardData::saveOne(const SaveData *save, const QString &saveAs, Type new
 
 	if (newType == Pc) {
 		// Rerelease 2013
-
 		QString filename = path.mid(path.lastIndexOf('/') + 1);
-		QRegExp regExp("slot([12])_save(\\d\\d).ff8");
-
-		if (regExp.exactMatch(filename)) {
+		QRegularExpression regExp("slot([12])_save(\\d\\d).ff8");
+		QRegularExpressionMatch match = regExp.match(filename);
+		if (match.hasMatch()) {
 			QString dirname = path.left(path.lastIndexOf('/'));
 			userDirectory.setDirname(dirname);
-
 			if (userDirectory.hasMetadata() && userDirectory.openMetadata()) {
-				QStringList capturedTexts = regExp.capturedTexts();
-				slot = quint8(capturedTexts.at(1).toInt());
-				num = quint8(capturedTexts.at(2).toInt());
+				slot = quint8(match.captured(1).toInt());
+				num = quint8(match.captured(2).toInt());
 			} else if (!userDirectory.hasMetadata()) {
 				setErrorString(QObject::tr("Le fichier 'metadata.xml' n'a pas été trouvé dans le dossier '%1'.\n"
 										   "Essayez de signer vos sauvegardes manuellement (Fichier > Signer les sauv. pour le Cloud).").arg(dirname));


### PR DESCRIPTION
I had trouble building Hyne on my Debian unstable system due to qt6core5compat.
To fix my build, I replaced all the remaining Qt5 API calls with their corresponding Qt6 equivalents, so the dependency on core5compat can be removed.
Maybe this is useful for other users :-)