### PR TITLE
CI: Fix artifact names + fix project version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   main_build:
-    name: ${{ matrix.package_suffix }} ${{ matrix.interface }}
+    name: ${{ matrix.package_suffix }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -136,7 +136,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: vcpkg-logs-${{ matrix.package_suffix }}-${{ matrix.interface }}-${{ matrix.build_type }}
+        name: vcpkg-logs-${{ matrix.package_suffix }}-${{ matrix.build_type }}
         path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
 
     - name: Build AppImage (Linux)
@@ -154,16 +154,16 @@ jobs:
           -e "${{ env.hyne_installation_path }}"/bin/Hyne \
           -d "${{ env.hyne_installation_path }}"/share/applications/io.github.myst6re.hyne.desktop \
           -i "${{ env.hyne_installation_path }}"/share/icons/hicolor/256x256/apps/io.github.myst6re.hyne.png
-        mv *.AppImage hyne-continuous-${{ matrix.interface }}-${{ matrix.package_suffix }}.AppImage
+        mv *.AppImage hyne-continuous-${{ matrix.package_suffix }}.AppImage
 
     - name: Prepare Upload
       shell: bash
-      run: mv ../build-hyne/*.${{ matrix.package_extension }} hyne-continuous-${{ matrix.interface }}-${{ matrix.package_suffix }}.${{ matrix.package_extension }}
+      run: mv ../build-hyne/*.${{ matrix.package_extension }} hyne-continuous-${{ matrix.package_suffix }}.${{ matrix.package_extension }}
 
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
-        name: artifact-${{ matrix.package_suffix }}-${{ matrix.interface }}
+        name: artifact-${{ matrix.package_suffix }}
         path: ${{ github.workspace }}/hyne-continuous-*.*
 
   deb_builder:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(NOT PRERELEASE_STRING)
     set(PRERELEASE_STRING "")
 endif()
 
-project("Hyne" VERSION 1.0.0 LANGUAGES CXX
+project("Hyne" VERSION 1.11.4 LANGUAGES CXX
     DESCRIPTION "Final Fantasy VIII savegame editor"
     HOMEPAGE_URL "https://github.com/myst6re/hyne"
 )


### PR DESCRIPTION
Unfortunately I missed two important fixes since #33 

The CI fix is about the artifact names containing a `--` in the name, which was there because before we had a target interface ( gui vs cli ), but since we dropped that we had to drop also the naming in the CI.

The other fix is I mistakenly forgot to update the `project()` version in the `CMakeLists.txt` file, which should now be aligned with the current Hyne version. This will fix the `.deb` package version ( in both filename and internal package version ).

For a comparison feel free to compare my https://github.com/julianxhokaxhiu/hyne/releases/tag/continuous release with yours.