### PR TITLE
CI: Add arm64 support for Windows/Linux + Bump Qt 6.8.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,10 @@ jobs:
           - 6.8.2
         os:
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - macos-latest
           - windows-latest
+          - windows-11-arm
         build_type:
           - Release
         include:
@@ -30,16 +32,25 @@ jobs:
           qt_modules: qt5compat
         - os: ubuntu-latest
           package_extension: 'tar.xz'
-          package_suffix: 'linux64'
+          package_suffix: 'linux_x64'
+        - os: ubuntu-24.04-arm
+          package_extension: 'tar.xz'
+          package_suffix: 'linux_arm64'
         - os: macos-latest
           package_extension: 'dmg'
           package_suffix: 'macos'
           cmake_extra_args: "-DCMAKE_OSX_ARCHITECTURES=\"arm64;x86_64\" -DVCPKG_TARGET_TRIPLET=\"universal-osx\""
         - os: windows-latest
           package_extension: 'zip'
-          package_suffix: 'win64'
+          package_suffix: 'win_x64'
           win_arch: "x64"
           qt_arch: win64_msvc2022_64
+          qt_tools: tools_ninja, tools_cmake
+        - os: windows-11-arm
+          package_extension: 'zip'
+          package_suffix: 'win_arm64'
+          win_arch: "arm64"
+          qt_arch: win64_msvc2022_arm64
           qt_tools: tools_ninja, tools_cmake
 
     env:
@@ -116,11 +127,21 @@ jobs:
       run: |
         echo "PRERELEASE_STRING= unstable build" >> $GITHUB_ENV
 
-    - name: Download linuxdeployqt
-      if: runner.os == 'Linux'
+    - name: Download linuxdeployqt (x64)
+      if: runner.os == 'Linux' && runner.arch == 'X64'
       run: |
         wget -qc "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
         wget -qc "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
+        export VERSION=continuous
+        chmod a+x linuxdeploy*.AppImage
+        mv linuxdeploy-plugin-qt-*.AppImage $QT_ROOT_DIR/bin/linuxdeploy-plugin-qt
+        mv linuxdeploy-*.AppImage $QT_ROOT_DIR/bin/linuxdeploy
+
+    - name: Download linuxdeployqt (ARM64)
+      if: runner.os == 'Linux' && runner.arch == 'ARM64'
+      run: |
+        wget -qc "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-aarch64.AppImage"
+        wget -qc "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-aarch64.AppImage"
         export VERSION=continuous
         chmod a+x linuxdeploy*.AppImage
         mv linuxdeploy-plugin-qt-*.AppImage $QT_ROOT_DIR/bin/linuxdeploy-plugin-qt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
   create: null
 
 env:
-  debianRequirements: "build-essential git zlib1g-dev cmake qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools qt6-declarative-dev qt6-base-dev libqt6svg6-dev qt6-base-dev-tools qt6-translations-l10n libqt6core5compat6-dev libqt6opengl6-dev libgl1-mesa-dev wget curl devscripts"
+  debianRequirements: "build-essential git zlib1g-dev cmake qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools qt6-declarative-dev qt6-base-dev libqt6svg6-dev qt6-base-dev-tools qt6-translations-l10n libqt6core5compat6-dev libgl1-mesa-dev wget curl devscripts"
 
 jobs:
   main_build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         qt:
-          - 6.8.2
+          - 6.8.3
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ add_compile_definitions(
     HYNE_VERSION_TWEAK=0
 )
 
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets OpenGLWidgets OpenGL LinguistTools Core5Compat REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets LinguistTools Core5Compat REQUIRED)
 find_package(ZLIB REQUIRED)
 
 set(LANGS
@@ -201,9 +201,7 @@ endif()
 qt_add_executable(${RELEASE_NAME} MANUAL_FINALIZATION MACOSX_BUNDLE WIN32 ${PROJECT_SOURCES} ${QM_FILES} ${RESOURCES} ${EXTRA_RESOURCES_GUI})
 target_include_directories(${RELEASE_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/src")
 target_link_libraries(${RELEASE_NAME} PRIVATE
-    Qt::OpenGL
     Qt::Widgets
-    Qt::OpenGLWidgets
     ZLIB::ZLIB
 )
 


### PR DESCRIPTION
Did also some minor cleanup and remove unused Qt modules like Qt6OpenGLWidgets as we're not using them anyway in the code. Adding them at the current state breaks the Windows ARM64 builds ( see https://github.com/miurahr/aqtinstall/issues/932 ), it won't be a problem for Hyne but might be for Deling/Makou so I'd not rush adding this there for now.

Here you can find the new ARM64 artifacts: https://github.com/julianxhokaxhiu/hyne/actions/runs/16552514224